### PR TITLE
Synthesize untradeable candies with tradeable ones, not just in pairs

### DIFF
--- a/packages/garbo/src/resources/synthesis.ts
+++ b/packages/garbo/src/resources/synthesis.ts
@@ -1,38 +1,56 @@
 import {
   availableAmount,
   Effect,
+  mallPrice,
   mySpleenUse,
   retrieveItem,
   spleenLimit,
   sweetSynthesis,
   sweetSynthesisResult,
 } from "kolmafia";
-import { $items, clamp } from "libram";
+import { $item, $items, clamp } from "libram";
 import { shuffle } from "../lib";
 
-const whitelist = $items`sugar shotgun, sugar shillelagh, sugar shank, sugar chapeau, sugar shorts, sugar shield, sugar shirt, Fudgie Roll`;
+const allowList = $items`Fudgie Roll, peanut brittle shield, sugar shotgun, sugar shillelagh, sugar shank, sugar chapeau, sugar shorts, sugar shield, sugar shirt`;
+
+// For safety, explicitly skip candies that are no longer obtainable or extremely rare
+const blockList = new Set([
+  $item`candied nuts`,
+  $item`candy kneecapping stick`,
+  $item`chocolate cigar`,
+  $item`fancy but probably evil chocolate`,
+  $item`fancy chocolate`,
+  $item`fancy chocolate car`,
+  $item`gummi ammonite`,
+  $item`gummi belemnite`,
+  $item`gummi trilobite`,
+  $item`powdered candy sushi set`,
+  $item`radio button candy`,
+  $item`spiritual candy cane`,
+  $item`Ultra Mega Sour Ball`,
+  $item`vitachoconutriment capsule`,
+]);
+
 export default function synthesize(casts: number, effect: Effect): void {
-  const shuffledWhitelist = shuffle([...whitelist]);
-  for (const itemA of shuffledWhitelist) {
-    if (availableAmount(itemA) <= 1) continue;
-    if (casts <= 0) return;
-    for (const itemB of shuffledWhitelist) {
-      const minimum = itemA === itemB ? 2 : 1;
-      if (availableAmount(itemB) <= minimum) continue;
-      if (sweetSynthesisResult(itemA, itemB) !== effect) continue;
-      const possibleCasts =
-        itemA === itemB
-          ? Math.floor((availableAmount(itemA) - 1) / 2)
-          : Math.min(availableAmount(itemA), availableAmount(itemB)) - 1;
+  const saveLimit = 1;
+  const buyableCandies = $items
+    .all()
+    .filter((i) => i.tradeable && i.candyType === "complex" && !blockList.has(i))
+    .sort((a, b) => mallPrice(a) - mallPrice(b))
+    .slice(0, 50);
+  const shuffledAllowlist = shuffle(allowList);
+  for (const untradeable of shuffledAllowlist) {
+    if (availableAmount(untradeable) <= saveLimit) continue;
+    for (const buyable of buyableCandies) {
+      if (sweetSynthesisResult(untradeable, buyable) !== effect) continue;
+      const possibleCasts = availableAmount(untradeable) - saveLimit;
       const spleen = Math.max(spleenLimit() - mySpleenUse(), 0);
       const castsToDo = Math.min(possibleCasts, casts, spleen);
       if (castsToDo === 0) continue;
-      if (itemA === itemB) retrieveItem(itemA, castsToDo * 2);
-      else {
-        retrieveItem(itemA, castsToDo);
-        retrieveItem(itemB, castsToDo);
-      }
-      if (sweetSynthesis(castsToDo, itemA, itemB)) casts -= castsToDo;
+      retrieveItem(untradeable, castsToDo);
+      retrieveItem(buyable, castsToDo);
+      if (sweetSynthesis(castsToDo, untradeable, buyable)) casts -= castsToDo;
+      if (casts <= 0) return;
     }
   }
 

--- a/packages/garbo/src/resources/synthesis.ts
+++ b/packages/garbo/src/resources/synthesis.ts
@@ -35,7 +35,9 @@ export default function synthesize(casts: number, effect: Effect): void {
   const saveLimit = 1;
   const buyableCandies = $items
     .all()
-    .filter((i) => i.tradeable && i.candyType === "complex" && !blockList.has(i))
+    .filter(
+      (i) => i.tradeable && i.candyType === "complex" && !blockList.has(i),
+    )
     .sort((a, b) => mallPrice(a) - mallPrice(b))
     .slice(0, 50);
   const shuffledAllowlist = shuffle(allowList);


### PR DESCRIPTION
Currently, sugar chapeau and sugar shirt tend to build up in quantity because the distribution of untradeable candies is biased towards some item ids.

Additionally, add peanut brittle shield to the list.