### PR TITLE
Remove tot special casing from meatFamiliar

### DIFF
--- a/src/familiar/meatFamiliar.ts
+++ b/src/familiar/meatFamiliar.ts
@@ -1,11 +1,5 @@
 import { Familiar } from "kolmafia";
-import {
-  $familiar,
-  findFairyMultiplier,
-  findLeprechaunMultiplier,
-  have,
-  maxBy,
-} from "libram";
+import { $familiar, findFairyMultiplier, findLeprechaunMultiplier, have, maxBy } from "libram";
 
 let fam: Familiar;
 

--- a/src/familiar/meatFamiliar.ts
+++ b/src/familiar/meatFamiliar.ts
@@ -1,7 +1,6 @@
-import { Familiar, inebrietyLimit, myInebriety } from "kolmafia";
+import { Familiar } from "kolmafia";
 import {
   $familiar,
-  $item,
   findFairyMultiplier,
   findLeprechaunMultiplier,
   have,
@@ -36,13 +35,7 @@ export function setBestLeprechaunAsMeatFamiliar(): void {
 
 export function meatFamiliar(): Familiar {
   if (!fam) {
-    if (
-      myInebriety() > inebrietyLimit() &&
-      have($familiar`Trick-or-Treating Tot`) &&
-      have($item`li'l pirate costume`)
-    ) {
-      fam = $familiar`Trick-or-Treating Tot`;
-    } else if (have($familiar`Robortender`)) {
+    if (have($familiar`Robortender`)) {
       fam = $familiar`Robortender`;
     } else {
       setBestLeprechaunAsMeatFamiliar();


### PR DESCRIPTION
When we fight embezzlers while overdrunk, we don't use the wineglass so there's no reason to prioritize the tot. And tot already exists as a `constantValueFamiliar` so there's no reason to add it as a special case for barf.