### PR TITLE
Dont try to use water breathing equipment we can't equip

### DIFF
--- a/src/barfTurn.ts
+++ b/src/barfTurn.ts
@@ -1,6 +1,7 @@
 import {
   availableAmount,
   canAdventure,
+  canEquip,
   cliExecute,
   currentRound,
   eat,
@@ -83,7 +84,7 @@ function shouldGoUnderwater(): boolean {
 
   if (
     !getModifier("Adventure Underwater") &&
-    waterBreathingEquipment.every((item) => !have(item))
+    waterBreathingEquipment.every((item) => !have(item) || !canEquip(item))
   ) {
     return false;
   }

--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -2,6 +2,7 @@ import { OutfitSpec } from "grimoire-kolmafia";
 import {
   booleanModifier,
   canAdventure,
+  canEquip,
   chatPrivate,
   cliExecute,
   getClanLounge,
@@ -203,7 +204,7 @@ function checkUnderwater() {
     !(get("_envyfishEggUsed") || have($item`envyfish egg`)) &&
     (get("_garbo_weightChain", false) || !have($familiar`Pocket Professor`)) &&
     (booleanModifier("Adventure Underwater") ||
-      waterBreathingEquipment.some((item) => have(item))) &&
+      waterBreathingEquipment.some((item) => have(item) && canEquip(item))) &&
     (have($effect`Fishy`) || (have($item`fishy pipe`) && !get("_fishyPipeUsed")))
   ) {
     if (!have($effect`Fishy`) && !get("_fishyPipeUsed")) use($item`fishy pipe`);

--- a/src/fights.ts
+++ b/src/fights.ts
@@ -2692,7 +2692,9 @@ function yachtzee(): void {
         : $familiar.none;
       useFamiliar(familiarChoice);
 
-      const underwaterBreathingGear = waterBreathingEquipment.find((item) => have(item));
+      const underwaterBreathingGear = waterBreathingEquipment.find(
+        (item) => have(item) && canEquip(item),
+      );
       if (!underwaterBreathingGear) return;
       const equippedOutfit = new Requirement(["meat", "-tie"], {
         forceEquip: [underwaterBreathingGear],


### PR DESCRIPTION
Noticed I was having leftover forced NC's, we should probably track when a Yachtzee wasn't successful.

Anyways, I didn't meet the stat requirements for "aerated diving helmet" but the script didn't recognize that when the maximizer failed. This fixes the attempt to use equipment I couldn't wear.