### PR TITLE
First stage of scepter support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "core-js": "^3.32.0",
     "grimoire-kolmafia": "^0.3.22",
     "kolmafia": "^5.27495.0",
-    "libram": "^0.8.5",
+    "libram": "^0.8.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/diet.ts
+++ b/src/diet.ts
@@ -84,6 +84,7 @@ import { Potion, PotionTier } from "./potions";
 import synthesize from "./synthesis";
 import { estimatedGarboTurns } from "./turns";
 import { garboValue } from "./value";
+import { shouldAugustCast } from "./resources";
 
 const MPA = get("valueOfAdventure");
 print(`Using adventure value ${MPA}.`, HIGHLIGHT);
@@ -285,6 +286,7 @@ const stomachLiverCleaners = new Map([
   [$item`synthetic dog hair pill`, [0, -1]],
   [$item`cuppa Sobrie tea`, [0, -1]],
   [$item`designer sweatpants`, [0, -1]],
+  [$item`august scepter`, [-1, 0]],
 ]);
 
 function legendaryPizzaToMenu(
@@ -433,6 +435,11 @@ function menu(): MenuItem<Note>[] {
       size: -1,
       organ: "booze",
       maximum: Math.min(3 - get("_sweatOutSomeBoozeUsed"), Math.floor(get("sweat") / 25)),
+    }),
+    new MenuItem($item`august scepter`, {
+      size: -1,
+      organ: "food",
+      maximum: shouldAugustCast($skill`Aug. 16th: Roller Coaster Day!`) ? 1 : 0,
     }),
   ].filter((item) => item.price() < Infinity) as MenuItem<Note>[];
 }
@@ -1019,6 +1026,7 @@ export function consumeDiet(diet: Diet<Note>, name: DietName): void {
             }
           },
         ],
+        [$item`august scepter`, () => useSkill($skill`Aug. 16th: Roller Coaster Day!`)],
       ]);
 
       for (const menuItem of menuItems) {

--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -289,7 +289,7 @@ export const chainStarters = [
   new EmbezzlerFight(
     "Scepter Semirare",
     () => shouldAugustCast($skill`Aug. 2nd: Find an Eleven-Leaf Clover Day`),
-    () => (shouldAugustCast($skill`Aug. 2nd: Find an Eleven-Leaf Clover Day`) ? 1 : 0),
+    () => 0, // prevent circular reference
     (options: EmbezzlerFightRunOptions) => {
       retrieveItem($item`august scepter`);
       useSkill($skill`Aug. 2nd: Find an Eleven-Leaf Clover Day`);

--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -19,6 +19,7 @@ import {
   toInt,
   toUrl,
   use,
+  useSkill,
   visitUrl,
   wait,
 } from "kolmafia";
@@ -59,6 +60,7 @@ import {
 } from "./lib";
 import { waterBreathingEquipment } from "./outfit";
 import wanderer, { DraggableFight } from "./wanderer";
+import { shouldAugustCast } from "./resources";
 
 const embezzler = $monster`Knob Goblin Embezzler`;
 
@@ -282,6 +284,21 @@ export const chainStarters = [
     (options: EmbezzlerFightRunOptions) => {
       faxEmbezzler();
       withMacro(options.macro, () => use($item`photocopied monster`), options.useAuto);
+    },
+  ),
+  new EmbezzlerFight(
+    "Scepter Semirare",
+    () => shouldAugustCast($skill`Aug. 2nd: Find an Eleven-Leaf Clover Day`),
+    () => (shouldAugustCast($skill`Aug. 2nd: Find an Eleven-Leaf Clover Day`) ? 1 : 0),
+    (options: EmbezzlerFightRunOptions) => {
+      retrieveItem($item`august scepter`);
+      useSkill($skill`Aug. 2nd: Find an Eleven-Leaf Clover Day`);
+      if (!have($effect`Lucky!`)) {
+        set("_aug2Cast", true);
+        return;
+      }
+      const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
+      adventureFunction($location`Cobb's Knob Treasury`, options.macro, options.macro);
     },
   ),
   new EmbezzlerFight(

--- a/src/potions.ts
+++ b/src/potions.ts
@@ -65,7 +65,7 @@ import { embezzlerCount } from "./embezzler";
 import { usingPurse } from "./outfit";
 import { estimatedGarboTurns } from "./turns";
 import { globalOptions } from "./config";
-import { castAugustScepterBuffs } from "./resources/scepter";
+import { castAugustScepterBuffs } from "./resources";
 
 export type PotionTier = "embezzler" | "overlap" | "barf" | "ascending";
 const banned = $items`Uncle Greenspan's Bathroom Finance Guide`;

--- a/src/potions.ts
+++ b/src/potions.ts
@@ -65,6 +65,7 @@ import { embezzlerCount } from "./embezzler";
 import { usingPurse } from "./outfit";
 import { estimatedGarboTurns } from "./turns";
 import { globalOptions } from "./config";
+import { castAugustScepterBuffs } from "./resources/scepter";
 
 export type PotionTier = "embezzler" | "overlap" | "barf" | "ascending";
 const banned = $items`Uncle Greenspan's Bathroom Finance Guide`;
@@ -161,6 +162,7 @@ export interface PotionOptions {
     maxAggregateCost?: number | undefined,
     tryRetrievingUntradeable?: boolean,
   ) => number;
+  effectValues?: Partial<{ meatDrop: number; itemDrop: number; famWeight: number }>;
 }
 
 export class Potion {
@@ -179,6 +181,7 @@ export class Potion {
     maxAggregateCost?: number | undefined,
     tryRetrievingUntradeable?: boolean,
   ) => number;
+  effectValues?: Partial<{ meatDrop: number; smithsness: number; famWeight: number }>;
 
   constructor(potion: Item, options: PotionOptions = {}) {
     this.potion = potion;
@@ -189,6 +192,7 @@ export class Potion {
     this.priceOverride = options.price;
     this.useOverride = options.use;
     this.acquire = options.acquire ?? acquire;
+    this.effectValues = options.effectValues;
   }
 
   doubleDuration(): Potion {
@@ -217,15 +221,19 @@ export class Potion {
     );
   }
 
+  smithsness(): number {
+    return this.effectValues?.smithsness ?? getModifier("Smithsness", this.effect());
+  }
+
   meatDrop(): number {
     return (
-      getModifier("Meat Drop", this.effect()) +
-      2 * (usingPurse() ? getModifier("Smithsness", this.effect()) : 0)
+      this.effectValues?.meatDrop ??
+      getModifier("Meat Drop", this.effect()) + 2 * (usingPurse() ? this.smithsness() : 0)
     );
   }
 
   familiarWeight(): number {
-    return getModifier("Familiar Weight", this.effect());
+    return this.effectValues?.famWeight ?? getModifier("Familiar Weight", this.effect());
   }
 
   bonusMeat(): number {
@@ -611,6 +619,7 @@ export function potionSetupCompleted(): boolean {
  * @param embezzlersOnly Are we valuing the potions only for embezzlers (noBarf)?
  */
 export function potionSetup(embezzlersOnly: boolean): void {
+  castAugustScepterBuffs();
   // TODO: Count PYEC.
   // TODO: Count free fights (25 meat each for most).
   withLocation($location.none, () => {

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,0 +1,1 @@
+export * from "./scepter";

--- a/src/resources/scepter.ts
+++ b/src/resources/scepter.ts
@@ -87,7 +87,7 @@ const SKILL_OPTIONS: ScepterSkill[] = [
   },
   {
     skill: $skill`Aug. 18th: Serendipity Day!`,
-    value: () => 1000, // Dummy value; we should some day calculate this based on free fight count, careful to avoid circular imports
+    value: () => 3000, // Dummy value; we should some day calculate this based on free fight count, careful to avoid circular imports
     type: "buff",
   },
   {

--- a/src/resources/scepter.ts
+++ b/src/resources/scepter.ts
@@ -151,7 +151,7 @@ function getBestScepterSkills(): ScepterSkill[] {
     .splice(0, clamp(5 - get("_augSkillsCast"), 0, 5)));
 }
 
-function shouldCast(skill: Skill) {
+export function shouldAugustCast(skill: Skill) {
   return (
     (getBestScepterSkills().some((s) => skill === s.skill) &&
       skill.dailylimit &&
@@ -163,7 +163,7 @@ function shouldCast(skill: Skill) {
 function summonTask({ skill }: ScepterSkill) {
   return {
     name: skill.name,
-    completed: () => !shouldCast(skill),
+    completed: () => !shouldAugustCast(skill),
     do: () => useSkill(skill),
   };
 }
@@ -177,7 +177,7 @@ export function augustSummonTasks() {
 export function castAugustScepterBuffs() {
   if (AugustScepter.have()) {
     for (const { skill } of SKILL_OPTIONS.filter(
-      ({ skill, type }) => shouldCast(skill) && type === "buff",
+      ({ skill, type }) => shouldAugustCast(skill) && type === "buff",
     )) {
       useSkill(skill);
     }
@@ -185,7 +185,7 @@ export function castAugustScepterBuffs() {
     const today = SKILL_OPTIONS.find(({ skill }) => skill === AugustScepter.todaysSkill());
     if (today && !AugustScepter.getTodayCast()) useSkill(today.skill);
 
-    if (globalOptions.ascend && shouldCast($skill`Aug. 13th: Left/Off Hander's Day!`)) {
+    if (globalOptions.ascend && shouldAugustCast($skill`Aug. 13th: Left/Off Hander's Day!`)) {
       useSkill($skill`Aug. 13th: Left/Off Hander's Day!`);
     }
   }

--- a/src/resources/scepter.ts
+++ b/src/resources/scepter.ts
@@ -18,7 +18,6 @@ import { EMBEZZLER_MULTIPLIER } from "../lib";
 import { Potion } from "../potions";
 import { garboAverageValue, garboValue } from "../value";
 import { canAdventure, canEquip, Item, myLevel, myMeat, Skill, toSlot, useSkill } from "kolmafia";
-import { doingExtrovermectin } from "../extrovermectin";
 
 type ScepterSkill = {
   skill: Skill;
@@ -26,11 +25,7 @@ type ScepterSkill = {
   type: "special" | "summon" | "buff";
 };
 const SKILL_OPTIONS: ScepterSkill[] = [
-  {
-    skill: $skill`Aug. 1st: Mountain Climbing Day!`,
-    value: () => (doingExtrovermectin() ? 3 * get("valueOfAdventure") : 0), // TODO: Meat drops
-    type: "special", // Want to specifically do before embezzlers
-  },
+  // August 1 deliberately omitted; does not trigger on monster replacers
   {
     skill: $skill`Aug. 2nd: Find an Eleven-Leaf Clover Day`,
     value: () =>

--- a/src/resources/scepter.ts
+++ b/src/resources/scepter.ts
@@ -1,0 +1,192 @@
+import {
+  $effect,
+  $familiar,
+  $item,
+  $items,
+  $location,
+  $skill,
+  $slot,
+  AugustScepter,
+  clamp,
+  get,
+  getModifier,
+  have,
+} from "libram";
+import { globalOptions } from "../config";
+import { embezzlerCount } from "../embezzler";
+import { EMBEZZLER_MULTIPLIER } from "../lib";
+import { Potion } from "../potions";
+import { garboAverageValue, garboValue } from "../value";
+import { canAdventure, canEquip, Item, myLevel, myMeat, Skill, toSlot, useSkill } from "kolmafia";
+import { doingExtrovermectin } from "../extrovermectin";
+
+type ScepterSkill = {
+  skill: Skill;
+  value: () => number;
+  type: "special" | "summon" | "buff";
+};
+const SKILL_OPTIONS: ScepterSkill[] = [
+  {
+    skill: $skill`Aug. 1st: Mountain Climbing Day!`,
+    value: () => (doingExtrovermectin() ? 3 * get("valueOfAdventure") : 0), // TODO: Meat drops
+    type: "special", // Want to specifically do before embezzlers
+  },
+  {
+    skill: $skill`Aug. 2nd: Find an Eleven-Leaf Clover Day`,
+    value: () =>
+      canAdventure($location`Cobb's Knob Treasury`)
+        ? EMBEZZLER_MULTIPLIER() * get("valueOfAdventure")
+        : 0,
+    type: "special",
+  },
+  {
+    skill: $skill`Aug. 3rd: Watermelon Day!`,
+    value: () => 3 * garboValue($item`watermelon`),
+    type: "summon",
+  },
+  {
+    skill: $skill`Aug. 4th: Water Balloon Day!`,
+    value: () => 3 * garboValue($item`water balloon`),
+    type: "summon",
+  },
+  {
+    skill: $skill`Aug. 5th: Oyster Day!`,
+    value: () =>
+      3 *
+      garboAverageValue(
+        ...$items`brilliant oyster egg, gleaming oyster egg, glistening oyster egg, lustrous oyster egg, magnificent oyster egg, pearlescent oyster egg, scintillating oyster egg`,
+      ),
+    type: "summon",
+  },
+  {
+    skill: $skill`Aug. 7th: Lighthouse Day!`,
+    value: () =>
+      new Potion($item`august scepter`, {
+        effect: $effect`Incredibly Well Lit`,
+        duration: 30,
+      }).gross(embezzlerCount()), // TODO: Yachtzee
+    type: "buff",
+  },
+  {
+    skill: $skill`Aug. 13th: Left/Off Hander's Day!`,
+    value: () =>
+      new Potion($item`august scepter`, {
+        effect: $effect`Offhand Remarkable`,
+        duration: 30,
+        effectValues: { meatDrop: 60 }, // Half a purse
+      }).gross(embezzlerCount()) +
+      (globalOptions.ascend
+        ? 0
+        : (5 + (have($familiar`Left-Hand Man`) ? 5 : 0)) * get("valueOfAdventure")),
+    type: "special", // Don't want to cast right away
+  },
+  {
+    skill: $skill`Aug. 14th: Financial Awareness  Day!`,
+    value: () => Math.min(100 * myLevel(), 1500, myMeat()) / 2,
+    type: "summon",
+  },
+  {
+    skill: $skill`Aug. 16th: Roller Coaster Day!`,
+    value: () => 8 * get("valueOfAdventure"),
+    type: "special",
+  },
+  {
+    skill: $skill`Aug. 18th: Serendipity Day!`,
+    value: () => 1000, // Dummy value; we should some day calculate this based on free fight count, careful to avoid circular imports
+    type: "buff",
+  },
+  {
+    skill: $skill`Aug. 24th: Waffle Day!`,
+    value: () => 3 * garboValue($item`waffle`),
+    type: "summon",
+  },
+  {
+    skill: $skill`Aug. 25th: Banana Split Day!`,
+    value: () => garboValue($item`banana split`),
+    type: "summon",
+  },
+  {
+    skill: $skill`Aug. 26th: Toilet Paper Day!`,
+    value: () => garboValue($item`handful of toilet paper`),
+    type: "summon",
+  },
+  {
+    skill: $skill`Aug. 29th: More Herbs, Less Salt  Day!`,
+    value: () => 3 * garboValue($item`Mrs. Rush`),
+    type: "summon",
+  },
+  {
+    skill: $skill`Aug. 30th: Beach Day!`,
+    value: () =>
+      100 +
+      (globalOptions.ascend
+        ? 0
+        : clamp(
+            7 -
+              getModifier(
+                "Adventures",
+                Item.all()
+                  .filter((i) => have(i) && toSlot(i) === $slot`acc1` && canEquip(i))
+                  .sort((a, b) => getModifier("Adventures", b) - getModifier("Adventures", a))[2] ??
+                  $item.none,
+              ),
+            0,
+            7,
+          ) * get("valueOfAdventure")),
+    type: "summon",
+  },
+  {
+    skill: $skill`Aug. 31st: Cabernet Sauvignon  Day!`,
+    value: () => 2 * garboValue($item`bottle of Cabernet Sauvignon`),
+    type: "summon",
+  },
+];
+
+let bestScepterSkills: ScepterSkill[] | null = null;
+function getBestScepterSkills(): ScepterSkill[] {
+  return (bestScepterSkills ??= SKILL_OPTIONS.filter(
+    ({ skill }) => AugustScepter.todaysSkill() !== skill,
+  )
+    .sort((a, b) => b.value() - a.value())
+    .splice(0, clamp(5 - get("_augSkillsCast"), 0, 5)));
+}
+
+function shouldCast(skill: Skill) {
+  return (
+    (getBestScepterSkills().some((s) => skill === s.skill) &&
+      skill.dailylimit &&
+      get("_augSkillsCast") < 5) ||
+    (AugustScepter.todaysSkill() === skill && !AugustScepter.getTodayCast())
+  );
+}
+
+function summonTask({ skill }: ScepterSkill) {
+  return {
+    name: skill.name,
+    completed: () => !shouldCast(skill),
+    do: () => useSkill(skill),
+  };
+}
+
+export function augustSummonTasks() {
+  return AugustScepter.have()
+    ? SKILL_OPTIONS.filter(({ type }) => type === "summon").map(summonTask)
+    : [];
+}
+
+export function castAugustScepterBuffs() {
+  if (AugustScepter.have()) {
+    for (const { skill } of SKILL_OPTIONS.filter(
+      ({ skill, type }) => shouldCast(skill) && type === "buff",
+    )) {
+      useSkill(skill);
+    }
+
+    const today = SKILL_OPTIONS.find(({ skill }) => skill === AugustScepter.todaysSkill());
+    if (today && !AugustScepter.getTodayCast()) useSkill(today.skill);
+
+    if (globalOptions.ascend && shouldCast($skill`Aug. 13th: Left/Off Hander's Day!`)) {
+      useSkill($skill`Aug. 13th: Left/Off Hander's Day!`);
+    }
+  }
+}

--- a/src/resources/scepter.ts
+++ b/src/resources/scepter.ts
@@ -73,7 +73,7 @@ const SKILL_OPTIONS: ScepterSkill[] = [
       new Potion($item`august scepter`, {
         effect: $effect`Offhand Remarkable`,
         duration: 30,
-        effectValues: { meatDrop: 60 }, // Half a purse
+        effectValues: { meatDrop: 80 }, // Half a purse
       }).gross(embezzlerCount()) +
       (globalOptions.ascend
         ? 0

--- a/src/resources/scepter.ts
+++ b/src/resources/scepter.ts
@@ -148,10 +148,11 @@ function getBestScepterSkills(): ScepterSkill[] {
 
 export function shouldAugustCast(skill: Skill) {
   return (
-    (getBestScepterSkills().some((s) => skill === s.skill) &&
+    AugustScepter.have() &&
+    ((getBestScepterSkills().some((s) => skill === s.skill) &&
       skill.dailylimit &&
       get("_augSkillsCast") < 5) ||
-    (AugustScepter.todaysSkill() === skill && !AugustScepter.getTodayCast())
+      (AugustScepter.todaysSkill() === skill && !AugustScepter.getTodayCast()))
   );
 }
 

--- a/src/resources/scepter.ts
+++ b/src/resources/scepter.ts
@@ -36,7 +36,7 @@ const SKILL_OPTIONS: ScepterSkill[] = [
   },
   {
     skill: $skill`Aug. 3rd: Watermelon Day!`,
-    value: () => 3 * garboValue($item`watermelon`),
+    value: () => garboValue($item`watermelon`),
     type: "summon",
   },
   {
@@ -178,7 +178,9 @@ export function castAugustScepterBuffs() {
       useSkill(skill);
     }
 
-    const today = SKILL_OPTIONS.find(({ skill }) => skill === AugustScepter.todaysSkill());
+    const today = SKILL_OPTIONS.find(
+      ({ skill, type }) => type === "buff" && skill === AugustScepter.todaysSkill(),
+    );
     if (today && !AugustScepter.getTodayCast()) useSkill(today.skill);
 
     if (globalOptions.ascend && shouldAugustCast($skill`Aug. 13th: Left/Off Hander's Day!`)) {

--- a/src/tasks/dailyItems.ts
+++ b/src/tasks/dailyItems.ts
@@ -47,6 +47,7 @@ import { coinmasterPrice } from "../lib";
 import { rufusPotion } from "../potions";
 import { garboAverageValue, garboValue } from "../value";
 import { GarboTask } from "./engine";
+import { augustSummonTasks } from "../resources/scepter";
 
 const SummonTomes = $skills`Summon Snowcones, Summon Stickers, Summon Sugar Sheets, Summon Rad Libs, Summon Smithsness`;
 const Wads = $items`twinkly wad, cold wad, stench wad, hot wad, sleaze wad, spooky wad`;
@@ -418,6 +419,7 @@ const DailyItemTasks: GarboTask[] = [
         1500: 3,
       },
     },
+    ...augustSummonTasks()
   ],
 ];
 

--- a/src/tasks/dailyItems.ts
+++ b/src/tasks/dailyItems.ts
@@ -47,7 +47,7 @@ import { coinmasterPrice } from "../lib";
 import { rufusPotion } from "../potions";
 import { garboAverageValue, garboValue } from "../value";
 import { GarboTask } from "./engine";
-import { augustSummonTasks } from "../resources/scepter";
+import { augustSummonTasks } from "../resources";
 
 const SummonTomes = $skills`Summon Snowcones, Summon Stickers, Summon Sugar Sheets, Summon Rad Libs, Summon Smithsness`;
 const Wads = $items`twinkly wad, cold wad, stench wad, hot wad, sleaze wad, spooky wad`;

--- a/src/tasks/dailyItems.ts
+++ b/src/tasks/dailyItems.ts
@@ -419,7 +419,7 @@ const DailyItemTasks: GarboTask[] = [
         1500: 3,
       },
     },
-    ...augustSummonTasks()
+    ...augustSummonTasks(),
   ],
 ];
 

--- a/src/yachtzee/diet.ts
+++ b/src/yachtzee/diet.ts
@@ -45,15 +45,9 @@ import synthesize from "../synthesis";
 import { estimatedGarboTurns } from "../turns";
 import { yachtzeePotionProfits, yachtzeePotionSetup } from "./buffs";
 import { optimizeForFishy } from "./fishy";
-import {
-  acquiringOffhandRemarkable,
-  cinchNCs,
-  freeNCs,
-  pyecAvailable,
-  shrugIrrelevantSongs,
-  useSpikolodonSpikes,
-} from "./lib";
+import { cinchNCs, freeNCs, pyecAvailable, shrugIrrelevantSongs, useSpikolodonSpikes } from "./lib";
 import { freeRest } from "../lib";
+import { shouldAugustCast } from "../resources";
 
 class YachtzeeDietEntry<T> {
   name: string;
@@ -274,11 +268,7 @@ export function executeNextDietStep(stopBeforeJellies?: boolean): void {
         const entry = dietUtil.dietArray.find((entry) => entry.name === name);
         if (entry) {
           if (entry.fullness > 0) {
-            if (
-              have($skill`Aug. 16th: Roller Coaster Day!`) &&
-              !get("_aug16Cast") &&
-              myFullness() > 0
-            ) {
+            if (shouldAugustCast($skill`Aug. 16th: Roller Coaster Day!`) && myFullness() > 0) {
               useSkill($skill`Aug. 16th: Roller Coaster Day!`);
             }
             if (!get("_milkOfMagnesiumUsed")) {
@@ -506,12 +496,7 @@ export function yachtzeeChainDiet(simOnly?: boolean): boolean {
   );
   const syntheticPillsAvailable =
     !get("_syntheticDogHairPillUsed") && have($item`synthetic dog hair pill`) ? 1 : 0;
-  const lostStomachAvailable =
-    have($skill`Aug. 16th: Roller Coaster Day!`) &&
-    !get("_aug16Cast") &&
-    get("_augSkillsCast") <= 3 + toInt(!acquiringOffhandRemarkable) // No need to save a charge if we aren't acquiring Offhand Remarkable
-      ? 1
-      : 0;
+  const lostStomachAvailable = shouldAugustCast($skill`Aug. 16th: Roller Coaster Day!`) ? 1 : 0;
 
   const currentSpleenLeft = spleenLimit() - mySpleenUse();
   let filters = 3 - get("currentMojoFilters");

--- a/src/yachtzee/fishy.ts
+++ b/src/yachtzee/fishy.ts
@@ -8,7 +8,6 @@ import {
   haveEquipped,
   mallPrice,
   print,
-  toInt,
   use,
   useSkill,
 } from "kolmafia";
@@ -28,8 +27,9 @@ import {
 import { acquire } from "../acquire";
 import { garboAdventure, Macro } from "../combat";
 import { safeRestore } from "../lib";
-import { acquiringOffhandRemarkable, pyecAvailable, yachtzeeBuffValue } from "./lib";
+import { pyecAvailable, yachtzeeBuffValue } from "./lib";
 import { getBestWaterBreathingEquipment } from "./outfit";
+import { shouldAugustCast } from "../resources";
 
 function fishyCloverAdventureOpportunityCost(pipe: boolean) {
   const willBeFishy = pipe || have($effect`Fishy`);
@@ -203,12 +203,7 @@ export function optimizeForFishy(yachtzeeTurns: number, setup?: boolean): number
       cost: canAdventure($location`The Brinier Deepers`)
         ? (have($effect`Lucky!`)
             ? 0
-            : have($skill`Aug. 2nd: Find an Eleven-Leaf Clover Day`) &&
-              !get("_aug2Cast") &&
-              get("_augSkillsCast") <=
-                2 +
-                  toInt(get("_aug16Cast")) + // No need to save a charge for stomache cleansing if we've already used the skill
-                  toInt(!acquiringOffhandRemarkable) // No need to save a charge if we aren't acquiring Offhand Remarkable
+            : shouldAugustCast($skill`Aug. 2nd: Find an Eleven-Leaf Clover Day`)
             ? 0
             : Infinity) +
           get("valueOfAdventure") +

--- a/src/yachtzee/lib.ts
+++ b/src/yachtzee/lib.ts
@@ -1,4 +1,4 @@
-import { cliExecute, Effect, Item, todayToString, toInt } from "kolmafia";
+import { cliExecute, Effect, Item } from "kolmafia";
 import {
   $effect,
   $familiar,
@@ -114,9 +114,3 @@ export function useSpikolodonSpikes(): void {
 
   postCombatActions();
 }
-
-// Save a charge for Offhand Remarkable if ...
-export const acquiringOffhandRemarkable =
-  !get("_aug13Cast") && // we haven't casted the skill yet
-  !globalOptions.ascend && // we are aren't ascending
-  toInt(todayToString().slice(-2)) !== 13; // the skill isn't a free-cast today

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,10 +2644,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libram@^0.8.5:
-  version "0.8.6"
-  resolved "https://registry.yarnpkg.com/libram/-/libram-0.8.6.tgz#06b8c27647d7ad0da32c943fe11bb6afccdbe0f2"
-  integrity sha512-UdhfR/ZclXCJfM2i3yHdoq1qqALAH/X9XVYjlg4GN3RG8PuM6+gLznHTPCa/I2kLsJ3uRacE8ijPiWlVcUSSxQ==
+libram@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/libram/-/libram-0.8.7.tgz#7059d7f736a3bfb89b7262970ae5b774484d2257"
+  integrity sha512-pzRNa/HBArnTcRhMHjnyTaFIxFcmyL9trGXWrr5Wm/JIHK57MpDxl/3F1vIjT9i0o3o1rWISC6w+ObbyCmTayQ==
   dependencies:
     html-entities "^2.4.0"
 


### PR DESCRIPTION
TO DO:
 - ~~find a way to add roller coaster to diet and yachtzee diet without circular imports~~
 - ~~cast mountain specifically pre-embezzler~~removed
 - ~~add clover to embezzlers~~ ~~and yachtzee~~,
 - after free fight revamp: add free fights
 - probably make us have quest-generating functions instead of static lists