### PR TITLE
Cast Recall Facts on Embezzlers instead

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -375,13 +375,6 @@ export class Macro extends StrictMacro {
         myClass() === $class`Cheese Wizard` && myFamiliar().experience < 400,
         Macro.trySkill($skill`Stilton Splatter`),
       )
-      .externalIf(
-        have($skill`Recall Facts: %phylum Circadian Rhythms`) && !get("_circadianRhythmsRecalled"),
-        Macro.if_(
-          $monster`garbage tourist`,
-          Macro.trySkill($skill`Recall Facts: %phylum Circadian Rhythms`),
-        ),
-      )
       .kill();
   }
 
@@ -696,6 +689,11 @@ export class Macro extends StrictMacro {
         .externalIf(
           SourceTerminal.getDigitizeMonster() !== embezzler || shouldRedigitize(),
           Macro.tryCopier($skill`Digitize`),
+        )
+        .externalIf(
+          have($skill`Recall Facts: %phylum Circadian Rhythms`) &&
+            !get("_circadianRhythmsRecalled"),
+          Macro.trySkill($skill`Recall Facts: %phylum Circadian Rhythms`),
         )
         .tryCopier($item`Spooky Putty sheet`)
         .tryCopier($item`Rain-Doh black box`)

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -687,13 +687,13 @@ export class Macro extends StrictMacro {
           Macro.trySkill($skill`Recall Facts: Monster Habitats`),
         )
         .externalIf(
-          SourceTerminal.getDigitizeMonster() !== embezzler || shouldRedigitize(),
-          Macro.tryCopier($skill`Digitize`),
-        )
-        .externalIf(
           have($skill`Recall Facts: %phylum Circadian Rhythms`) &&
             !get("_circadianRhythmsRecalled"),
           Macro.trySkill($skill`Recall Facts: %phylum Circadian Rhythms`),
+        )
+        .externalIf(
+          SourceTerminal.getDigitizeMonster() !== embezzler || shouldRedigitize(),
+          Macro.tryCopier($skill`Digitize`),
         )
         .tryCopier($item`Spooky Putty sheet`)
         .tryCopier($item`Rain-Doh black box`)


### PR DESCRIPTION
Since you are much more likely to fight 10 of these in a row, and works for a broader set of user usecases.