### PR TITLE
stop garbo from infinite loop meat loss

### DIFF
--- a/src/embezzler.ts
+++ b/src/embezzler.ts
@@ -68,6 +68,7 @@ import { waterBreathingEquipment } from "./outfit";
 import wanderer, { DraggableFight } from "./wanderer";
 import { MonsterProperty, NumericProperty } from "libram/dist/propertyTypes";
 import { shouldAugustCast } from "./resources";
+import { garboValue } from "./value";
 
 const embezzler = $monster`Knob Goblin Embezzler`;
 
@@ -578,7 +579,13 @@ export const gregFights = (
       () => (get(monsterProp) === embezzler ? totalCharges() : 0),
       (options: EmbezzlerFightRunOptions) => {
         const run = ltbRun();
-        run.constraints.preparation?.();
+        run.constraints.preparation?.();  
+        // if garbo is way too meat negative, hard abort because something bad is happening.
+        //   in my experience garbo can spend up to 1.5-2 mil on diet but if garbo is at -3mil
+        //   something very bad is happening and garbo should stop. 
+        if (garboValue < -3000000) {
+          abort("Garbo is spending way too much meat on freeruns; it probably thinks you have a greg that you don't. Setting beGregariousFightsLeft = 0 might fix Garbo. Or it might not! Who knows, in this life.");
+        }
         const adventureFunction = options.useAuto ? garboAdventureAuto : garboAdventure;
         adventureFunction(
           $location`The Dire Warren`,


### PR DESCRIPTION
garbo has trouble handling misaligned gregs and the way we have handled this has led to a very bad nigh-infinite meat loss problem where the system, if your greg count gets off, just continually buys and throws LTBs. this has led to an unfortunate -70 mil meat day for kas and -30 for another user. 

this is not a great solution, but it is a simple one -- check garbovalue pre-greg and abort if garbo is more than 3 million meat in the red. even for some theoretical garbo user who is at t0 and hasn't made a single bit of meat, diet never costs more than 1.5-2 mil, so if garbo is at -3 something has gone horribly wrong and it is continually cycling some bit of code. realistically this may even be worth abstracting out of embezzies into a general purpose function called after freefights have been run but for now this feels like a very simple fix for very bad behavior