### PR TITLE
feat: actually check types when running CI test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install --frozen-lockfile
-      - run: yarn run build
+      - run: yarn run check
       #- run: yarn run test TODO: Readd once we have tests
 
   lint:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "node esbuild/build-all.mjs",
     "watch": "node esbuild/build-all.mjs --watch",
     "deploy": "copyfiles --up 1 --exclude \"**/dependencies.txt\" \"KoLmafia/**/*\" \"mafia/**/*\"",
+    "check": "tsc",
     "lint": "eslint src && prettier --check .",
     "lint:fix": "eslint src --fix && prettier --check --write .",
     "madge": "madge --circular ./src/index.ts ./relay/** ./src/**"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "noImplicitReturns": true,
     "pretty": true,
     "strict": true,
-    "target": "esnext"
+    "target": "esnext",
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],
   "isolatedModules": true /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */


### PR DESCRIPTION
`tsc` is already configured with `noEmit`, so it can be run straight.

Add `skipLibCheck` as otherwise you get errors with duplicate definitions in `react` and `react-dom`.