### PR TITLE
bofa value

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "core-js": "^3.32.2",
     "grimoire-kolmafia": "^0.3.22",
-    "kolmafia": "^5.27598.0",
+    "kolmafia": "^5.27625.0",
     "libram": "^0.8.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "core-js": "^3.32.2",
     "grimoire-kolmafia": "^0.3.22",
-    "kolmafia": "^5.27625.0",
+    "kolmafia": "^5.27628.0",
     "libram": "^0.8.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/garboWanderer.ts
+++ b/src/garboWanderer.ts
@@ -1,9 +1,9 @@
-import { Effect, Location } from "kolmafia";
+import { Effect, getMonsters, Location } from "kolmafia";
 import { globalOptions } from "./config";
 import { freeFightFamiliarData } from "./familiar/freeFightFamiliar";
 import { estimatedGarboTurns } from "./turns";
 import { WandererManager } from "./libgarbo";
-import { $item, get } from "libram";
+import { $item, $location, $monster, $monsters, get, have } from "libram";
 import { garboValue } from "./garboValue";
 import { Potion } from "./potions";
 import { embezzlerCount } from "./embezzler/fights";
@@ -22,6 +22,11 @@ export function wanderer(): WandererManager {
       freeFightExtraValue: (location: Location) =>
         freeFightFamiliarData({ location }).expectedValue,
       digitzesRemaining: digitizedMonstersRemainingForTurns,
+      plentifulMonsters: [
+        $monster`Knob Goblin Embezzler`,
+        ...(globalOptions.nobarf ? [] : getMonsters($location`Barf Mountain`)),
+        ...(have($item`Kramco Sausage-o-Matic™`) ? $monsters`sausage goblin` : []),
+      ],
     });
   }
   return _wanderer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ export function canContinue(): boolean {
 }
 
 export function main(argString = ""): void {
-  sinceKolmafiaRevision(27625);
+  sinceKolmafiaRevision(27628);
   checkGithubVersion();
 
   // Hit up main.php to get out of easily escapable choices

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ export function canContinue(): boolean {
 }
 
 export function main(argString = ""): void {
-  sinceKolmafiaRevision(27593);
+  sinceKolmafiaRevision(27625);
   checkGithubVersion();
 
   // Hit up main.php to get out of easily escapable choices

--- a/src/libgarbo/wanderer/lib.ts
+++ b/src/libgarbo/wanderer/lib.ts
@@ -32,6 +32,7 @@ export type WandererFactoryOptions = {
   freeFightExtraValue: (loc: Location) => number;
   itemValue: (item: Item) => number;
   effectValue: (effect: Effect, duration: number) => number;
+  plentifulMonsters: Monster[];
   prioritizeCappingGuzzlr: boolean;
   digitzesRemaining?: (turns: number) => number;
 };

--- a/src/libgarbo/wanderer/lib.ts
+++ b/src/libgarbo/wanderer/lib.ts
@@ -4,6 +4,7 @@ import {
   Effect,
   effectFact,
   Item,
+  itemFact,
   Location,
   Monster,
   myClass,
@@ -273,18 +274,20 @@ const LIMITED_BOFA_DROPS = $items`pocket wish, tattered scrap of paper`;
 export function bofaValue(options: WandererFactoryOptions, monster: Monster): number {
   switch (monster.factType) {
     case "item": {
-      const item = toItem(monster.fact);
+      const item = itemFact(myClass(), myPath(), monster);
+      const quantity = numericFact(myClass(), myPath(), monster);
       if (
         LIMITED_BOFA_DROPS.includes(item) &&
         options.plentifulMonsters.some((monster) => toItem(monster.fact) === item)
       ) {
         return 0;
       }
-      return options.itemValue(item);
+      return quantity * options.itemValue(item);
     }
     case "effect": {
       const effect = effectFact(myClass(), myPath(), monster);
-      return options.effectValue(effect, numericFact(myClass(), myPath(), monster));
+      const duration = numericFact(myClass(), myPath(), monster);
+      return options.effectValue(effect, duration);
     }
     default:
       return 0;

--- a/src/libgarbo/wanderer/lib.ts
+++ b/src/libgarbo/wanderer/lib.ts
@@ -2,13 +2,13 @@ import {
   buy,
   canAdventure,
   Effect,
+  effectFact,
   Item,
   Location,
   Monster,
   myClass,
   myPath,
   numericFact,
-  toEffect,
   toItem,
   use,
 } from "kolmafia";
@@ -283,7 +283,7 @@ export function bofaValue(options: WandererFactoryOptions, monster: Monster): nu
       return options.itemValue(item);
     }
     case "effect": {
-      const effect = toEffect(monster.fact);
+      const effect = effectFact(myClass(), myPath(), monster);
       return options.effectValue(effect, numericFact(myClass(), myPath(), monster));
     }
     default:

--- a/src/libgarbo/wanderer/lib.ts
+++ b/src/libgarbo/wanderer/lib.ts
@@ -7,8 +7,6 @@ import {
   itemFact,
   Location,
   Monster,
-  myClass,
-  myPath,
   numericFact,
   toItem,
   use,
@@ -277,8 +275,8 @@ export function bofaValue(
 ): number {
   switch (monster.factType) {
     case "item": {
-      const item = itemFact(myClass(), myPath(), monster);
-      const quantity = numericFact(myClass(), myPath(), monster);
+      const item = itemFact(monster);
+      const quantity = numericFact(monster);
       if (
         LIMITED_BOFA_DROPS.includes(item) &&
         plentifulMonsters.some((monster) => toItem(monster.fact) === item)
@@ -288,12 +286,12 @@ export function bofaValue(
       return quantity * itemValue(item);
     }
     case "effect": {
-      const effect = effectFact(myClass(), myPath(), monster);
-      const duration = numericFact(myClass(), myPath(), monster);
+      const effect = effectFact(monster);
+      const duration = numericFact(monster);
       return effectValue(effect, duration);
     }
     case "meat": {
-      return numericFact(myClass(), myPath(), monster);
+      return numericFact(monster);
     }
     default:
       return 0;

--- a/src/libgarbo/wanderer/lib.ts
+++ b/src/libgarbo/wanderer/lib.ts
@@ -271,23 +271,26 @@ export function wandererTurnsAvailableToday(
 }
 
 const LIMITED_BOFA_DROPS = $items`pocket wish, tattered scrap of paper`;
-export function bofaValue(options: WandererFactoryOptions, monster: Monster): number {
+export function bofaValue(
+  { plentifulMonsters, itemValue, effectValue }: WandererFactoryOptions,
+  monster: Monster,
+): number {
   switch (monster.factType) {
     case "item": {
       const item = itemFact(myClass(), myPath(), monster);
       const quantity = numericFact(myClass(), myPath(), monster);
       if (
         LIMITED_BOFA_DROPS.includes(item) &&
-        options.plentifulMonsters.some((monster) => toItem(monster.fact) === item)
+        plentifulMonsters.some((monster) => toItem(monster.fact) === item)
       ) {
         return 0;
       }
-      return quantity * options.itemValue(item);
+      return quantity * itemValue(item);
     }
     case "effect": {
       const effect = effectFact(myClass(), myPath(), monster);
       const duration = numericFact(myClass(), myPath(), monster);
-      return options.effectValue(effect, duration);
+      return effectValue(effect, duration);
     }
     case "meat": {
       return numericFact(myClass(), myPath(), monster);

--- a/src/libgarbo/wanderer/lib.ts
+++ b/src/libgarbo/wanderer/lib.ts
@@ -1,7 +1,21 @@
-import { buy, canAdventure, Effect, Item, Location, Monster, use } from "kolmafia";
+import {
+  buy,
+  canAdventure,
+  Effect,
+  Item,
+  Location,
+  Monster,
+  myClass,
+  myPath,
+  numericFact,
+  toEffect,
+  toItem,
+  use,
+} from "kolmafia";
 import {
   $effect,
   $item,
+  $items,
   $location,
   $locations,
   $skill,
@@ -255,7 +269,24 @@ export function wandererTurnsAvailableToday(
   return digitize + pigSkinnerRay + yellowRay + wanderers;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const LIMITED_BOFA_DROPS = $items`pocket wish, tattered scrap of paper`;
 export function bofaValue(options: WandererFactoryOptions, monster: Monster): number {
-  return 0;
+  switch (monster.factType) {
+    case "item": {
+      const item = toItem(monster.fact);
+      if (
+        LIMITED_BOFA_DROPS.includes(item) &&
+        options.plentifulMonsters.some((monster) => toItem(monster.fact) === item)
+      ) {
+        return 0;
+      }
+      return options.itemValue(item);
+    }
+    case "effect": {
+      const effect = toEffect(monster.fact);
+      return options.effectValue(effect, numericFact(myClass(), myPath(), monster));
+    }
+    default:
+      return 0;
+  }
 }

--- a/src/libgarbo/wanderer/lib.ts
+++ b/src/libgarbo/wanderer/lib.ts
@@ -289,6 +289,9 @@ export function bofaValue(options: WandererFactoryOptions, monster: Monster): nu
       const duration = numericFact(myClass(), myPath(), monster);
       return options.effectValue(effect, duration);
     }
+    case "meat": {
+      return numericFact(myClass(), myPath(), monster);
+    }
     default:
       return 0;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,10 +2718,10 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-kolmafia@^5.27598.0:
-  version "5.27598.0"
-  resolved "https://registry.yarnpkg.com/kolmafia/-/kolmafia-5.27598.0.tgz#6b364b0fd3e8f6b6cf7db4cb116bd62c7d1e8b09"
-  integrity sha512-K4iXfUe0g6N5PAV99YqWgEPu1ybxaRZ4EJyn+8Emy2KbaLY6/sbUKpMJVuACmKotCELcT7fF3LoDhapna/u7hQ==
+kolmafia@^5.27625.0:
+  version "5.27625.0"
+  resolved "https://registry.yarnpkg.com/kolmafia/-/kolmafia-5.27625.0.tgz#91f68bccf9ea66556289560b4aca9d57f6beb021"
+  integrity sha512-twC6p0f2jOhjsxgkMpy8Gl8puA+p3elx/olz0lBSEd6BLOk/7UdxkOqop2/aFhy3x00Av8Pj/SGEclBWEcz0qg==
 
 levn@^0.4.1:
   version "0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,10 +2718,10 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-kolmafia@^5.27625.0:
-  version "5.27625.0"
-  resolved "https://registry.yarnpkg.com/kolmafia/-/kolmafia-5.27625.0.tgz#91f68bccf9ea66556289560b4aca9d57f6beb021"
-  integrity sha512-twC6p0f2jOhjsxgkMpy8Gl8puA+p3elx/olz0lBSEd6BLOk/7UdxkOqop2/aFhy3x00Av8Pj/SGEclBWEcz0qg==
+kolmafia@^5.27628.0:
+  version "5.27628.0"
+  resolved "https://registry.yarnpkg.com/kolmafia/-/kolmafia-5.27628.0.tgz#f091f230be2b0ddf7ab0191b24cba69883798dce"
+  integrity sha512-w7qrZwUPgy3ac+PXGpCSro/MOrVZSwqpwz9QOyyskgnsGOH8hH+ckC07ryrWfpeg5b42EszkYbxTdKhFO0yyaA==
 
 levn@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
while I can use the `factType` proxy record in the switch--and doing so protects me from having to count pocket wish and tatter drops--wanting to check quantities of items and effects forces me to use the `itemFact`, `numericFact`, and `effectFact` functions instead of proxy records. Which is fine, but a little awkward given that I have to pass in the seed.