### PR TITLE
Fix embezzler choice causing a wanderer call

### DIFF
--- a/packages/garbo/src/tasks/barfTurn.ts
+++ b/packages/garbo/src/tasks/barfTurn.ts
@@ -293,9 +293,13 @@ const BarfTurnTasks: GarboTask[] = [
       shouldGoUnderwater()
         ? $location`The Briny Deeps`
         : wanderer().getTarget({ wanderer: "wanderer", allowEquipment: false }),
-    choices: shouldGoUnderwater()
-      ? {}
-      : wanderer().getChoices({ wanderer: "wanderer", allowEquipment: false }),
+    choices: () =>
+      shouldGoUnderwater()
+        ? {}
+        : wanderer().getChoices({
+            wanderer: "wanderer",
+            allowEquipment: false,
+          }),
     combat: new GarboStrategy(
       () =>
         Macro.externalIf(


### PR DESCRIPTION
This was causing a call at script start, as well as extra calls for each wandering embezzler