### PR TITLE
Enforce initialValue for reducers to avoid unexpected behaviour

### DIFF
--- a/packages/eslint-config-garbo/index.js
+++ b/packages/eslint-config-garbo/index.js
@@ -31,6 +31,14 @@ module.exports = {
 
     // eslint-plugin-libram
     "libram/verify-constants": "error",
+    "no-restricted-syntax": [
+      "error",
+      {
+        selector:
+          "CallExpression[callee.property.name='reduce'][arguments.length<2]",
+        message: "Provide initialValue to .reduce().",
+      },
+    ],
   },
   parserOptions: {
     ecmaVersion: 2020,

--- a/packages/garbo/src/familiar/freeFightFamiliar.ts
+++ b/packages/garbo/src/familiar/freeFightFamiliar.ts
@@ -139,8 +139,8 @@ export function getAllJellyfishDrops(): {
 
 export function freeFightFamiliarData(
   options: MenuOptions = {},
-): GeneralFamiliar | null {
-  const compareFamiliars = (a: GeneralFamiliar | null, b: GeneralFamiliar) => {
+): GeneralFamiliar {
+  const compareFamiliars = (a: GeneralFamiliar, b: GeneralFamiliar) => {
     if (a === null) return b;
     if (a.expectedValue === b.expectedValue) {
       return a.leprechaunMultiplier > b.leprechaunMultiplier ? a : b;
@@ -148,9 +148,14 @@ export function freeFightFamiliarData(
     return a.expectedValue > b.expectedValue ? a : b;
   };
 
-  return menu(options).reduce(compareFamiliars, null);
+  return menu(options).reduce(compareFamiliars, {
+    familiar: $familiar.none,
+    expectedValue: 0,
+    leprechaunMultiplier: 0,
+    limit: "none",
+  });
 }
 
 export function freeFightFamiliar(options: MenuOptions = {}): Familiar {
-  return freeFightFamiliarData(options)?.familiar ?? $familiar.none;
+  return freeFightFamiliarData(options).familiar;
 }

--- a/packages/garbo/src/familiar/freeFightFamiliar.ts
+++ b/packages/garbo/src/familiar/freeFightFamiliar.ts
@@ -139,17 +139,18 @@ export function getAllJellyfishDrops(): {
 
 export function freeFightFamiliarData(
   options: MenuOptions = {},
-): GeneralFamiliar {
-  const compareFamiliars = (a: GeneralFamiliar, b: GeneralFamiliar) => {
+): GeneralFamiliar | null {
+  const compareFamiliars = (a: GeneralFamiliar | null, b: GeneralFamiliar) => {
+    if (a === null) return b;
     if (a.expectedValue === b.expectedValue) {
       return a.leprechaunMultiplier > b.leprechaunMultiplier ? a : b;
     }
     return a.expectedValue > b.expectedValue ? a : b;
   };
 
-  return menu(options).reduce(compareFamiliars);
+  return menu(options).reduce(compareFamiliars, null);
 }
 
 export function freeFightFamiliar(options: MenuOptions = {}): Familiar {
-  return freeFightFamiliarData(options).familiar;
+  return freeFightFamiliarData(options)?.familiar ?? $familiar.none;
 }

--- a/packages/garbo/src/garboWanderer.ts
+++ b/packages/garbo/src/garboWanderer.ts
@@ -21,7 +21,7 @@ export function wanderer(): WandererManager {
         new Potion($item.none, { effect, duration }).gross(embezzlerCount()),
       prioritizeCappingGuzzlr: get("garbo_prioritizeCappingGuzzlr", false),
       freeFightExtraValue: (location: Location) =>
-        freeFightFamiliarData({ location }).expectedValue,
+        freeFightFamiliarData({ location })?.expectedValue ?? 0,
       digitzesRemaining: digitizedMonstersRemainingForTurns,
       plentifulMonsters: [
         $monster`Knob Goblin Embezzler`,

--- a/packages/garbo/src/garboWanderer.ts
+++ b/packages/garbo/src/garboWanderer.ts
@@ -21,7 +21,7 @@ export function wanderer(): WandererManager {
         new Potion($item.none, { effect, duration }).gross(embezzlerCount()),
       prioritizeCappingGuzzlr: get("garbo_prioritizeCappingGuzzlr", false),
       freeFightExtraValue: (location: Location) =>
-        freeFightFamiliarData({ location })?.expectedValue ?? 0,
+        freeFightFamiliarData({ location }).expectedValue,
       digitzesRemaining: digitizedMonstersRemainingForTurns,
       plentifulMonsters: [
         $monster`Knob Goblin Embezzler`,


### PR DESCRIPTION
Not sure what actually happened to the user in #1645 but this is good practice anyway. If we want to flag selecting no familiar as an error we should do so explicitly, not via a TypeError.

- Add eslint rule to enforce initial value for reducers
- Fix resulting linting errors
