### PR TITLE
Prevent faxbox abort if network is down

### DIFF
--- a/packages/garbo/src/embezzler/fights.ts
+++ b/packages/garbo/src/embezzler/fights.ts
@@ -1,7 +1,6 @@
 import {
   abort,
   canAdventure,
-  chatPrivate,
   cliExecute,
   getClanLounge,
   haveEquipped,
@@ -21,7 +20,6 @@ import {
   userConfirm,
   useSkill,
   visitUrl,
-  wait,
 } from "kolmafia";
 import { DraggableFight } from "garbo-lib";
 import { OutfitSpec } from "grimoire-kolmafia";
@@ -148,27 +146,6 @@ export class EmbezzlerFight implements EmbezzlerFightConfigOptions {
   }
 }
 
-function checkFax(): boolean {
-  if (!have($item`photocopied monster`)) cliExecute("fax receive");
-  if (property.getString("photocopyMonster") === "Knob Goblin Embezzler") {
-    return true;
-  }
-  cliExecute("fax send");
-  return false;
-}
-
-function faxEmbezzler(): void {
-  if (!get("_photocopyUsed")) {
-    if (checkFax()) return;
-    chatPrivate("cheesefax", "Knob Goblin Embezzler");
-    for (let i = 0; i < 3; i++) {
-      wait(10);
-      if (checkFax()) return;
-    }
-    throw new Error("Failed to acquire photocopied Knob Goblin Embezzler.");
-  }
-}
-
 export const chainStarters = [
   new EmbezzlerFight(
     "Chateau Painting",
@@ -208,15 +185,18 @@ export const chainStarters = [
     () =>
       have($item`Clan VIP Lounge key`) &&
       !get("_photocopyUsed") &&
+      have($item`photocopied monster`) &&
+      property.getString("photocopyMonster") === "Knob Goblin Embezzler" &&
       getClanLounge()["deluxe fax machine"] !== undefined,
     () =>
       have($item`Clan VIP Lounge key`) &&
       !get("_photocopyUsed") &&
+      have($item`photocopied monster`) &&
+      property.getString("photocopyMonster") === "Knob Goblin Embezzler" &&
       getClanLounge()["deluxe fax machine"] !== undefined
         ? 1
         : 0,
     (options: RunOptions) => {
-      faxEmbezzler();
       withMacro(
         options.macro,
         () => use($item`photocopied monster`),

--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -189,6 +189,7 @@ import { garboValue } from "./garboValue";
 import { wanderer } from "./garboWanderer";
 import { runEmbezzlerFight } from "./embezzler/execution";
 import { EmbezzlerFightRunOptions } from "./embezzler/staging";
+import { faxMonster } from "./resources/fax";
 
 const firstChainMacro = () =>
   Macro.if_(
@@ -431,6 +432,9 @@ export function dailyFights(): void {
   if (getFoldGroup($item`Spooky Putty sheet`).some((item) => have(item))) {
     cliExecute("fold spooky putty sheet");
   }
+
+  // Fax an embezzler before starting, to prevent an abort in case the faxbot networks are down
+  faxMonster($monster`Knob Goblin Embezzler`);
 
   if (embezzlerSources.some((source) => source.potential())) {
     withStash($items`Spooky Putty sheet`, () => {

--- a/packages/garbo/src/resources/fax.ts
+++ b/packages/garbo/src/resources/fax.ts
@@ -23,14 +23,12 @@ export function faxMonster(monster: Monster): boolean {
   if (getClanLounge()["deluxe fax machine"] === undefined) return false;
   if (get("_photocopyUsed")) return false;
 
-  if (!get("_photocopyUsed")) {
+  if (checkFax(monster)) return true;
+  if (!canFaxbot(monster)) return false;
+  faxbot(monster);
+  for (let i = 0; i < 3; i++) {
+    wait(10);
     if (checkFax(monster)) return true;
-    if (!canFaxbot(monster)) return false;
-    faxbot(monster);
-    for (let i = 0; i < 3; i++) {
-      wait(10);
-      if (checkFax(monster)) return true;
-    }
   }
   return false;
 }

--- a/packages/garbo/src/resources/fax.ts
+++ b/packages/garbo/src/resources/fax.ts
@@ -1,0 +1,36 @@
+import {
+  canFaxbot,
+  cliExecute,
+  faxbot,
+  getClanLounge,
+  Monster,
+  wait,
+} from "kolmafia";
+import { $item, get, have, property } from "libram";
+
+function checkFax(monster: Monster): boolean {
+  if (!have($item`photocopied monster`)) cliExecute("fax receive");
+  if (!have($item`photocopied monster`)) return false;
+  if (property.get("photocopyMonster") === monster) {
+    return true;
+  }
+  if (have($item`photocopied monster`)) cliExecute("fax send");
+  return false;
+}
+
+export function faxMonster(monster: Monster): boolean {
+  if (!have($item`Clan VIP Lounge key`)) return false;
+  if (getClanLounge()["deluxe fax machine"] === undefined) return false;
+  if (get("_photocopyUsed")) return false;
+
+  if (!get("_photocopyUsed")) {
+    if (checkFax(monster)) return true;
+    if (!canFaxbot(monster)) return false;
+    faxbot(monster);
+    for (let i = 0; i < 3; i++) {
+      wait(10);
+      if (checkFax(monster)) return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Try and get a photocopied monster before embezzlers are started rather than during execution
Use faxbot rather than messaging cheesefax directly (this is the same logic as autoscend)