### PR TITLE
fix: putty / raindoh remaining count

### DIFF
--- a/packages/garbo/src/embezzler/fights.ts
+++ b/packages/garbo/src/embezzler/fights.ts
@@ -304,58 +304,42 @@ export const copySources = [
       (have($item`Rain-Doh box full of monster`) &&
         get("rainDohMonster") === embezzler),
     () => {
-      const havePutty =
-        have($item`Spooky Putty sheet`) || have($item`Spooky Putty monster`);
-      const haveRainDoh =
-        have($item`Rain-Doh black box`) ||
-        have($item`Rain-Doh box full of monster`);
-      const puttyLocked =
-        have($item`Spooky Putty monster`) &&
-        get("spookyPuttyMonster") !== embezzler;
-      const rainDohLocked =
-        have($item`Rain-Doh box full of monster`) &&
-        get("rainDohMonster") !== embezzler;
+      const havePutty = have($item`Spooky Putty sheet`);
+      const havePuttyMonster = have($item`Spooky Putty monster`);
+      const haveRainDoh = have($item`Rain-Doh black box`);
+      const haveRainDohMonster = have($item`Rain-Doh box full of monster`);
 
-      if (havePutty && haveRainDoh) {
-        if (puttyLocked && rainDohLocked) return 0;
-        else if (puttyLocked) {
-          return (
-            5 -
-            get("_raindohCopiesMade") +
-            itemAmount($item`Rain-Doh box full of monster`)
-          );
-        } else if (rainDohLocked) {
-          return (
-            5 -
-            get("spookyPuttyCopiesMade") +
-            itemAmount($item`Spooky Putty monster`)
-          );
-        }
-        return (
-          6 -
-          get("spookyPuttyCopiesMade") -
-          get("_raindohCopiesMade") +
-          itemAmount($item`Spooky Putty monster`) +
-          itemAmount($item`Rain-Doh box full of monster`)
-        );
-      } else if (havePutty) {
-        if (puttyLocked) return 0;
-        return (
-          5 -
-          get("spookyPuttyCopiesMade") -
-          get("_raindohCopiesMade") +
-          itemAmount($item`Spooky Putty monster`)
-        );
-      } else if (haveRainDoh) {
-        if (rainDohLocked) return 0;
-        return (
-          5 -
-          get("spookyPuttyCopiesMade") -
-          get("_raindohCopiesMade") +
-          itemAmount($item`Rain-Doh box full of monster`)
-        );
+      const puttyUsed = get("spookyPuttyCopiesMade");
+      const rainDohUsed = get("_raindohCopiesMade");
+      const hardLimit = 6 - puttyUsed - rainDohUsed;
+      let monsterCount = 0;
+      let puttyLeft = 5 - puttyUsed;
+      let rainDohLeft = 5 - rainDohUsed;
+
+      if (!havePutty && !havePuttyMonster) {
+        puttyLeft = 0;
       }
-      return 0;
+      if (!haveRainDoh && !haveRainDohMonster) {
+        rainDohLeft = 0;
+      }
+
+      if (havePuttyMonster) {
+        if (get("spookyPuttyMonster") === embezzler) {
+          monsterCount++;
+        } else {
+          puttyLeft = 0;
+        }
+      }
+      if (haveRainDohMonster) {
+        if (get("rainDohMonster") === embezzler) {
+          monsterCount++;
+        } else {
+          rainDohLeft = 0;
+        }
+      }
+
+      const naiveLimit = Math.min(puttyLeft + rainDohLeft, hardLimit);
+      return naiveLimit + monsterCount;
     },
     (options: RunOptions) => {
       const macro = options.macro;


### PR DESCRIPTION
If you had a non-Embezzler copied monster and both a Rain-doh and a putty, the available amount was wrong, e.g.

```
_raindohCopiesMade: 5
rainDohMonster: deadly venomtrout
spookyPuttyCopiesMade: 1
spookyPuttyMonster: 
```

gives 4 remaining, but it should be 0.

I think the new logic is right, but I haven't tested it extensively.