### PR TITLE
UMD price check needs to compare against cap

### DIFF
--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -2634,7 +2634,7 @@ function yachtzee(): void {
       const getUMD =
         !get("_sleazeAirportToday") && // We cannot get the UMD with a one-day pass
         garboValue($item`Ultimate Mind Destroyer`) >=
-          2000 * (1 + numericModifier("meat drop") / 100) &&
+          Math.min(20000, 2000 * (1 + numericModifier("meat drop") / 100)) &&
         (!lastUMDDate ||
           gameDay().getTime() - Date.parse(lastUMDDate) >=
             1000 * 60 * 60 * 24 * 7);


### PR DESCRIPTION
technically this is a waste of meat buffs, but atm garbo is never getting UMD at all which is more of a loss. When the yatchzee code is cleaned up it should defer doing this until the post-barf turns if UMD is available

I haven't tested this yet my week reset isn't up