### PR TITLE
Workaround for candymap redirecting to a choice adventure

### DIFF
--- a/packages/garbo/src/resources/candyMap.ts
+++ b/packages/garbo/src/resources/candyMap.ts
@@ -8,6 +8,7 @@ import {
   maxBy,
   set,
   sum,
+  withChoice,
 } from "libram";
 import {
   canEquip,
@@ -19,6 +20,7 @@ import {
   print,
   runChoice,
   toItem,
+  use,
   visitUrl,
 } from "kolmafia";
 import { GarboTask } from "../tasks/engine";
@@ -106,7 +108,7 @@ function useCandyMapTask(): GarboTask {
           false,
         )
       ) {
-        visitUrl("inv_use.php?pwd&whichitem=11337");
+        withChoice(804, 2, () => use($item`map to a candy-rich block`));
         set("_mapToACandyRichBlockUsed", "true");
       }
     },

--- a/packages/garbo/src/resources/candyMap.ts
+++ b/packages/garbo/src/resources/candyMap.ts
@@ -1,5 +1,14 @@
 import { Outfit } from "grimoire-kolmafia";
-import { $familiar, $item, get, getSaleValue, have, maxBy, sum } from "libram";
+import {
+  $familiar,
+  $item,
+  get,
+  getSaleValue,
+  have,
+  maxBy,
+  set,
+  sum,
+} from "libram";
 import {
   canEquip,
   getOutfits,
@@ -10,7 +19,6 @@ import {
   print,
   runChoice,
   toItem,
-  use,
   visitUrl,
 } from "kolmafia";
 import { GarboTask } from "../tasks/engine";
@@ -98,7 +106,8 @@ function useCandyMapTask(): GarboTask {
           false,
         )
       ) {
-        use($item`map to a candy-rich block`);
+        visitUrl("inv_use.php?pwd&whichitem=11337");
+        set("_mapToACandyRichBlockUsed", "true");
       }
     },
     limit: { skip: 1 },


### PR DESCRIPTION
This should bypass it for now. Manually set the property just in case because it doesn't seem to work.