### PR TITLE
Reorder main function

### DIFF
--- a/packages/garbo/src/index.ts
+++ b/packages/garbo/src/index.ts
@@ -98,7 +98,14 @@ function ensureBarfAccess() {
 export function main(argString = ""): void {
   sinceKolmafiaRevision(27640);
   checkGithubVersion();
-  allMallPrices();
+
+  Args.fill(globalOptions, argString);
+  globalOptions.prefs.yachtzeechain = false;
+  if (globalOptions.version) return; // Since we always print the version, all done!
+  if (globalOptions.help) {
+    Args.showHelp(globalOptions);
+    return;
+  }
 
   // Hit up main.php to get out of easily escapable choices
   visitUrl("main.php");
@@ -113,13 +120,7 @@ export function main(argString = ""): void {
     );
   }
 
-  Args.fill(globalOptions, argString);
-  globalOptions.prefs.yachtzeechain = false;
-  if (globalOptions.version) return; // Since we always print the version, all done!
-  if (globalOptions.help) {
-    Args.showHelp(globalOptions);
-    return;
-  }
+  allMallPrices();
 
   if (globalOptions.turns) {
     if (globalOptions.turns >= 0) {


### PR DESCRIPTION
This change will reorder steps:
1) Show version
2) Show help
3) Abort if stuck in a choice or in combat
4) Update mall prices

Ideally version and help should work even if logged out and shouldn't depend on game state to work.
Mall prices should be checked after ensuring not stuck in a choice or combat, because the mall can't be accessed in either state.