### PR TITLE
no more historical price checks

### DIFF
--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -2569,7 +2569,7 @@ function killRobortCreaturesForFree() {
 const isFree = (monster: Monster) => monster.attributes.includes("FREE");
 const valueDrops = (monster: Monster) =>
   sum(itemDropsArray(monster), ({ drop, rate, type }) =>
-    !["c", "0", "p"].includes(type) ? (garboValue(drop, true) * rate) / 100 : 0,
+    !["c", "0", "p"].includes(type) ? (garboValue(drop) * rate) / 100 : 0,
   );
 
 export function estimatedFreeFights(): number {

--- a/packages/garbo/src/garboValue.ts
+++ b/packages/garbo/src/garboValue.ts
@@ -13,8 +13,8 @@ function garboValueFunctions(): ValueFunctions {
   return _valueFunctions;
 }
 
-export function garboValue(item: Item, useHistorical = false): number {
-  return garboValueFunctions().value(item, useHistorical);
+export function garboValue(item: Item): number {
+  return garboValueFunctions().value(item);
 }
 
 export function garboAverageValue(...items: Item[]): number {

--- a/packages/garbo/src/resources/autumnaton.ts
+++ b/packages/garbo/src/resources/autumnaton.ts
@@ -49,7 +49,7 @@ function averageAutumnatonValue(
       .map((m) => itemDropsArray(m))
       .flat()
       .map(({ rate, type, drop }) => ({
-        value: !["c", "0"].includes(type) ? garboValue(drop, true) : 0,
+        value: !["c", "0"].includes(type) ? garboValue(drop) : 0,
         preAcuityExpectation: ["c", "0", ""].includes(type)
           ? (2 * rate) / 100
           : 0,
@@ -95,7 +95,7 @@ function seasonalItemValue(
           availableAmount(autumnItem) > 0
           ? avgValueOfRandomAutumnItem
           : 0
-        : garboValue(autumnItem, true))
+        : garboValue(autumnItem))
     );
   } else {
     // If we're in a location without any uniques, we still get cowcatcher items

--- a/packages/garbo/src/tasks/dailyItems.ts
+++ b/packages/garbo/src/tasks/dailyItems.ts
@@ -97,7 +97,7 @@ function pickCargoPocket(): void {
     if (pocket in items) {
       value += sum(
         Object.entries(pocketItems(pocket)),
-        ([item, count]) => garboValue(toItem(item), true) * count,
+        ([item, count]) => garboValue(toItem(item)) * count,
       );
     }
     if (pocket in meats) {

--- a/packages/garbo/src/tasks/freeFight.ts
+++ b/packages/garbo/src/tasks/freeFight.ts
@@ -91,7 +91,7 @@ function bestWitchessPiece() {
 const isFree = (monster: Monster) => monster.attributes.includes("FREE");
 const valueDrops = (monster: Monster) =>
   sum(itemDropsArray(monster), ({ drop, rate, type }) =>
-    !["c", "0", "p"].includes(type) ? (garboValue(drop, true) * rate) / 100 : 0,
+    !["c", "0", "p"].includes(type) ? (garboValue(drop) * rate) / 100 : 0,
   );
 const locketMonster = () => CombatLoversLocket.findMonster(isFree, valueDrops);
 const locketsToSave = () =>


### PR DESCRIPTION
Left it in the garbolib stuff at the moment because it may be useful to some future script, but because we do a `mallPrices("allitems")` there's no need for it for us.