### PR TITLE
A partial fix for #1702

### DIFF
--- a/packages/garbo/src/resources/worksheds.ts
+++ b/packages/garbo/src/resources/worksheds.ts
@@ -107,7 +107,15 @@ export function trainNeedsRotating(): boolean {
 }
 
 export function rotateToOptimalCycle(): boolean {
-  return TrainSet.setConfiguration(getRotatedCycle());
+  const hasRotated = TrainSet.setConfiguration(getRotatedCycle());
+
+  // If the trainset was not configured but still claims to be configurable
+  if (!hasRotated && TrainSet.canConfigure()) {
+    // Set the trainset configuration to believe it'll be configurable in one turn
+    set("lastTrainsetConfiguration", get("trainsetPosition") - 39);
+  }
+
+  return hasRotated;
 }
 
 export function grabMedicine(): void {

--- a/packages/garbo/src/resources/worksheds.ts
+++ b/packages/garbo/src/resources/worksheds.ts
@@ -5,7 +5,16 @@ import {
   runChoice,
   visitUrl,
 } from "kolmafia";
-import { $item, $items, arrayEquals, get, maxBy, sum, TrainSet } from "libram";
+import {
+  $item,
+  $items,
+  arrayEquals,
+  get,
+  maxBy,
+  set,
+  sum,
+  TrainSet,
+} from "libram";
 import { globalOptions } from "../config";
 import { candyFactoryValue } from "../lib";
 import { garboAverageValue, garboValue } from "../garboValue";


### PR DESCRIPTION
I don't believe this fixes the underlying issue, but it should prevent garbo encountering a non-stop loop.
What it does is if the trainset was not configured, but is still configurable, set the last trainset configured counter to 39 trainset positions ago.
This should then tell garbo that we can configure the trainset in 1 train station instead of now.