### PR TITLE
disallow non-null assertions

### DIFF
--- a/packages/eslint-config-garbo/index.js
+++ b/packages/eslint-config-garbo/index.js
@@ -28,6 +28,7 @@ module.exports = {
     // This one needs a fix because TS's rules are different?
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-non-null-assertion": "error",
 
     // eslint-plugin-libram
     "libram/verify-constants": "error",

--- a/packages/garbo/src/tasks/dailyItems.ts
+++ b/packages/garbo/src/tasks/dailyItems.ts
@@ -413,7 +413,7 @@ const DailyItemTasks: GarboTask[] = [
     ready: () =>
       BurningLeaves.have() &&
       BurningLeaves.numberOfLeaves() >=
-        BurningLeaves.burnFor.get($item`lit leaf lasso`)!,
+        (BurningLeaves.burnFor.get($item`lit leaf lasso`) ?? Infinity),
     completed: () => get("_leafLassosCrafted") >= 3,
     do: () => BurningLeaves.burnSpecialLeaves($item`lit leaf lasso`),
     limit: { skip: 3 },
@@ -424,7 +424,7 @@ const DailyItemTasks: GarboTask[] = [
     ready: () =>
       BurningLeaves.have() &&
       BurningLeaves.numberOfLeaves() >=
-        BurningLeaves.burnFor.get($item`day shortener`)!,
+        (BurningLeaves.burnFor.get($item`day shortener`) ?? Infinity),
     completed: () => get("_leafDayShortenerCrafted"),
     do: () => BurningLeaves.burnSpecialLeaves($item`day shortener`),
     spendsTurn: false,


### PR DESCRIPTION
Maybe we should just extend `@typescript-eslint/strict`?