### PR TITLE
fix npm publish

### DIFF
--- a/.github/workflows/garbo-lib.yml
+++ b/.github/workflows/garbo-lib.yml
@@ -1,20 +1,22 @@
 name: Publish package to NPM
 on:
   push:
-    paths:
-      - "packages/garbo-lib/package.json"
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: "16.x"
+          node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Install
+        run: yarn workspace garbo-lib install
 
       - name: Check publish status
         id: check
@@ -22,8 +24,6 @@ jobs:
 
       - name: Publish if necessary
         if: ${{ steps.check.outputs.exists == '0' }}
-        run: |
-          yarn
-          yarn workspace garbo-lib npm publish
+        run: yarn workspace garbo-lib npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,3 +7,5 @@ plugins:
     spec: "@yarnpkg/plugin-interactive-tools"
 
 yarnPath: .yarn/releases/yarn-3.6.4.cjs
+
+npmAuthToken: ${NODE_AUTH_TOKEN-xxx}


### PR DESCRIPTION
- remove toastergazing (#1654)
- Don't abort if box of Familiar Jacks is expensive (#1653)
- add toastergaze stub function for future generations (#1655)
- grimoire free fights redux (#1652)
- handle limits nicer on free fight tasks (#1661)
- Re-add ML reductions to glitch (#1663)
- Add daily dungeon setting up and gazing (#1664)
- Autumnaton: Disregard daily dungeon monsters, count seasonal items (#1665)
- Dd2 (#1666)
- Force drunkula when DD drunk (#1669)
- fix DD trap choice (#1670)
- use lockpicks (#1672)
- Register forest unlock (#1678)
- Vamp out if profitable (#1676)
- Acquire sea jelly (#1680)
- UMD price check needs to compare against cap (#1677)
- Fix for yarn 2. This is fine because the root package is private
- fix: putty / raindoh remaining count (#1673)
- free goofballs (#1679)
- Add free candy support (#1662)
- Synthesize untradeable candies with tradeable ones, not just in pairs (#1407)
- Workaround for candymap redirecting to a choice adventure (#1684)
- support trick or treat combats (#1683)
- Support Sneegleeb and can of mixed everything (#1682)
- Reorder main function (#1693)
- add free fight value to candyMap value (#1686)
- Fix version check (#1694)
- use quest ready for nonbarf turns (#1691)
- Fix runtime getTarget call (#1695)
- fix: don't assume we can get a quake of arrows (#1692)
- check github for update (#1696)
- apply the `locationBanlist` much earlier in fallbot logic (#1700)
- Grimoirize post.ts (#1631)
- Fix missing cinch off by 1 error (#1703)
- beaten up handling (#1704)
- fix fill sweaty liver logic (#1708)
- Remove runtime mall searches (#1711)
- Automatically gather resin (#1714)
- Diet and Dailies (#1701)
- Do safe restore in grimoire prep (#1717)
- rollover cutoff not using grimoirized_post (#1697)
- fix comparison (#1719)
- can only cleave when we have turns (#1724)
- no more historical price checks (#1725)
- Value leaf rakes (#1728)
- handle carto NC for frat house (#1730)
- handle gingerbread wandering better (#1690)
- Friar loop fix (#1729)
- Move leaf value to garbo-lib (#1733)
- only attempt workshed tasks for worksheds with an action (#1737)
- move extinguisher above jellyfish & gingerbread (#1738)
- spacegate to skiplist (#1743)
- only rotate train when doing so does something (#1705)
- fix handling of underwater embezzler during barf-turn (#1744)
- Burn leaves for 3x lit leaf lasso & day shortener (#1736)
- A partial fix for #1702 (#1747)
- update libram to v0.8.17 (#1750)
- disallow non-null assertions (#1749)
- Add Scepter Free Fights When Today (#1580)
- Burning Leaf Implementation (#1748)
- update kolmafia -> ^5.27668.0 to match libram (#1751)
- update libram to match between garbo & garbo-lib (#1752)
- Fix up garbo-lib so it publishes properly
