### PR TITLE
August Scepter fix

### DIFF
--- a/packages/garbo/src/resources/scepter.ts
+++ b/packages/garbo/src/resources/scepter.ts
@@ -179,7 +179,7 @@ export function shouldAugustCast(skill: Skill) {
     ((getBestScepterSkills().some((s) => skill === s.skill) &&
       skill.dailylimit &&
       get("_augSkillsCast") < 5) ||
-      (AugustScepter.todaysSkill() === skill && !AugustScepter.getTodayCast()))
+      (AugustScepter.todaysSkill() === skill && !AugustScepter.getTodayCast() && skill.dailylimit))
   );
 }
 

--- a/packages/garbo/src/resources/scepter.ts
+++ b/packages/garbo/src/resources/scepter.ts
@@ -179,7 +179,9 @@ export function shouldAugustCast(skill: Skill) {
     ((getBestScepterSkills().some((s) => skill === s.skill) &&
       skill.dailylimit &&
       get("_augSkillsCast") < 5) ||
-      (AugustScepter.todaysSkill() === skill && !AugustScepter.getTodayCast() && skill.dailylimit))
+      (AugustScepter.todaysSkill() === skill &&
+        !AugustScepter.getTodayCast() &&
+        skill.dailylimit))
   );
 }
 

--- a/packages/garbo/src/resources/scepter.ts
+++ b/packages/garbo/src/resources/scepter.ts
@@ -1,4 +1,14 @@
 import {
+  canAdventure,
+  canEquip,
+  Item,
+  myLevel,
+  myMeat,
+  Skill,
+  toSlot,
+  useSkill,
+} from "kolmafia";
+import {
   $effect,
   $familiar,
   $item,
@@ -14,19 +24,9 @@ import {
 } from "libram";
 import { globalOptions } from "../config";
 import { embezzlerCount } from "../embezzler";
+import { garboAverageValue, garboValue } from "../garboValue";
 import { EMBEZZLER_MULTIPLIER } from "../lib";
 import { Potion } from "../potions";
-import { garboAverageValue, garboValue } from "../garboValue";
-import {
-  canAdventure,
-  canEquip,
-  Item,
-  myLevel,
-  myMeat,
-  Skill,
-  toSlot,
-  useSkill,
-} from "kolmafia";
 import { GarboTask } from "../tasks/engine";
 
 type ScepterSkill = {
@@ -181,7 +181,7 @@ export function shouldAugustCast(skill: Skill) {
       get("_augSkillsCast") < 5) ||
       (AugustScepter.todaysSkill() === skill &&
         !AugustScepter.getTodayCast() &&
-        skill.dailylimit))
+        skill.dailylimit >= 1))
   );
 }
 


### PR DESCRIPTION
Currently if you cast the TODAY skill while in run, Mafia flags the _augXCast as true but does not flag the _augTodayCast as true. As a result, if the run ends in the same day and garbo is run, shouldAugustCast considers the skill to be castable when it's already been cast for the day and is actually not castable. This should fix it (I think)