### PR TITLE
With every failed fax, wait 2 seconds longer

### DIFF
--- a/packages/garbo/src/resources/fax.ts
+++ b/packages/garbo/src/resources/fax.ts
@@ -27,7 +27,7 @@ export function faxMonster(monster: Monster): boolean {
   if (!canFaxbot(monster)) return false;
   faxbot(monster);
   for (let i = 0; i < 3; i++) {
-    wait(10);
+    wait(10 + (i * 2));
     if (checkFax(monster)) return true;
   }
   return false;

--- a/packages/garbo/src/resources/fax.ts
+++ b/packages/garbo/src/resources/fax.ts
@@ -27,7 +27,7 @@ export function faxMonster(monster: Monster): boolean {
   if (!canFaxbot(monster)) return false;
   faxbot(monster);
   for (let i = 0; i < 3; i++) {
-    wait(10 + (i * 2));
+    wait(10 + i * 2);
     if (checkFax(monster)) return true;
   }
   return false;


### PR DESCRIPTION
Aside from it being a good idea for multiple people using fax at the same time and thus always interfering with each other, it'd also help with OnlyFax now telling you off if you're spamming it with requests.