### PR TITLE
Actually name what action the macro was created for

### DIFF
--- a/packages/garbo/src/combat.ts
+++ b/packages/garbo/src/combat.ts
@@ -675,7 +675,7 @@ export class Macro extends StrictMacro {
     return new Macro().ghostBustin();
   }
 
-  embezzler(): Macro {
+  embezzler(action: string): Macro {
     const doneHabitat =
       !have($skill`Just the Facts`) ||
       (get("_monsterHabitatsRecalled") === 3 &&
@@ -732,12 +732,12 @@ export class Macro extends StrictMacro {
         )
         .meatKill(),
     ).abortWithMsg(
-      `Expected ${globalOptions.target} but encountered something else.`,
+      `Macro for ${action} expected ${globalOptions.target} but encountered something else.`,
     );
   }
 
-  static embezzler(): Macro {
-    return new Macro().embezzler();
+  static embezzler(action: string): Macro {
+    return new Macro().embezzler(action);
   }
 }
 

--- a/packages/garbo/src/embezzler/lib.ts
+++ b/packages/garbo/src/embezzler/lib.ts
@@ -47,6 +47,7 @@ export interface RunOptions {
   macro: Macro;
   location: Location;
   useAuto: boolean;
+  action: string;
 }
 
 export function checkUnderwater(): boolean {

--- a/packages/garbo/src/embezzler/staging.ts
+++ b/packages/garbo/src/embezzler/staging.ts
@@ -31,11 +31,13 @@ export class EmbezzlerFightRunOptions implements RunOptions {
   #macro?: Macro;
   #location?: Location;
   #useAuto?: boolean;
+  #action?: string;
   constructor(
     configOptions: EmbezzlerFightConfigOptions,
-    { macro, location, useAuto }: Partial<RunOptions> = {},
+    { macro, location, useAuto, action }: Partial<RunOptions> = {},
   ) {
     this.configOptions = configOptions;
+    this.#action = action;
     this.#macro = macro;
     this.#location = location;
     this.#useAuto = useAuto;
@@ -69,7 +71,7 @@ export class EmbezzlerFightRunOptions implements RunOptions {
   }
 
   get macro(): Macro {
-    const baseMacro = this.#macro ?? Macro.embezzler();
+    const baseMacro = this.#macro ?? Macro.embezzler(this.action);
     return this.configOptions.draggable === "wanderer"
       ? wandererFailsafeMacro().step(baseMacro)
       : baseMacro;
@@ -77,5 +79,9 @@ export class EmbezzlerFightRunOptions implements RunOptions {
 
   get useAuto(): boolean {
     return this.#useAuto ?? true;
+  }
+
+  get action(): string {
+    return this.#action ?? "???";
   }
 }

--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -384,7 +384,9 @@ function startWandererCounter() {
       }
       garboAdventure(
         $location`The Haunted Kitchen`,
-        Macro.if_(globalOptions.target, Macro.embezzler()).step(run.macro),
+        Macro.if_(globalOptions.target, Macro.embezzler("wanderer")).step(
+          run.macro,
+        ),
       );
     } while (
       get("lastCopyableMonster") === $monster`Government agent` ||
@@ -480,6 +482,7 @@ export function dailyFights(): void {
             runEmbezzlerFight(fightSource, {
               macro: macro(),
               useAuto: false,
+              action: "Pocket Professor",
             });
             eventLog.initialCopyTargetsFought +=
               1 + get("_pocketProfessorLectures") - startLectures;
@@ -548,7 +551,7 @@ export function dailyFights(): void {
         setLocation(location);
         embezzlerOutfit({ ...nextFight.spec, ...famSpec }, location).dress();
 
-        runEmbezzlerFight(nextFight);
+        runEmbezzlerFight(nextFight, { action: nextFight.name });
         postCombatActions();
 
         print(`Finished ${nextFight.name}`);

--- a/packages/garbo/src/resources/extrovermectin.ts
+++ b/packages/garbo/src/resources/extrovermectin.ts
@@ -460,7 +460,9 @@ function banishBunny(): void {
     banish.prepare?.();
     garboAdventure(
       $location`The Dire Warren`,
-      Macro.if_($monster`fluffy bunny`, banish.macro()).embezzler(),
+      Macro.if_($monster`fluffy bunny`, banish.macro()).embezzler(
+        "fluffy bunny banish",
+      ),
     );
   } while (
     "fluffy bunny" !== get("lastEncounter") &&

--- a/packages/garbo/src/tasks/barfTurn.ts
+++ b/packages/garbo/src/tasks/barfTurn.ts
@@ -532,7 +532,7 @@ const BarfTurnTasks: GarboTask[] = [
     do: () => use($item`envyfish egg`),
     spendsTurn: true,
     outfit: embezzlerOutfit,
-    combat: new GarboStrategy(() => Macro.embezzler()),
+    combat: new GarboStrategy(() => Macro.embezzler("envyfish egg")),
   },
   wanderTask(
     "yellow ray",


### PR DESCRIPTION
Changes this error blob from


```JavaScript exception: Combat exception! Last macro error: Macro Aborted ("abort "Expected Knob Goblin Embezzler but encountered something else.""). Exception KoLmafia error: You're on your own, partner. (Macro Aborted ("abort "Expected Knob Goblin Embezzler but encountered something else."")).```

to

```JavaScript exception: Combat exception! Last macro error: Macro Aborted ("abort "Macro for Macrometeorite expected Knob Goblin Embezzler but encountered something else.""). Exception KoLmafia error: You're on your own, partner. (Macro Aborted ("abort "Macro for Macrometeorite expected Knob Goblin Embezzler but encountered something else."")).```

Sure, with context you'll eventually figure it out. But this makes it easier to figure out what the script was trying to pull off.

Probably needs better wording.