### PR TITLE
feat: minimally support the Mini Kiwi as a drop familiar

### DIFF
--- a/packages/garbo/src/familiar/dropFamiliars.ts
+++ b/packages/garbo/src/familiar/dropFamiliars.ts
@@ -177,6 +177,11 @@ const rotatingFamiliars: StandardDropFamiliar[] = [
     additionalValue: () =>
       (6 + 4 * familiarWeight($familiar`Jill-of-All-Trades`)) * 0.33,
   },
+  {
+    familiar: $familiar`Mini Kiwi`,
+    expected: () => 4, // faster with aviator goggles
+    drop: $item`mini kiwi`,
+  },
 ];
 
 export default function getDropFamiliars(): GeneralFamiliar[] {


### PR DESCRIPTION
Requires a new libram for the familiar and drop item.

This should be enough to crash the item prices without aviator goggles support.