### PR TITLE
Support bindlestocking crit drops

### DIFF
--- a/packages/garbo/src/combat.ts
+++ b/packages/garbo/src/combat.ts
@@ -214,7 +214,8 @@ export class Macro extends StrictMacro {
     const pigSkinnerSetup = have($skill`Head in the Game`);
 
     const willCrit =
-      equippedAmount($item`mafia pointer finger ring`) > 0 &&
+      (equippedAmount($item`mafia pointer finger ring`) > 0 ||
+        equippedAmount($item`bindlestocking`) > 0) &&
       (sealClubberSetup ||
         opsSetup ||
         katanaSetup ||

--- a/packages/garbo/src/outfit/dropsgear.ts
+++ b/packages/garbo/src/outfit/dropsgear.ts
@@ -6,6 +6,7 @@ import {
   Item,
   mallPrice,
   myFullness,
+  myFury,
   numericModifier,
   toSlot,
 } from "kolmafia";
@@ -14,6 +15,7 @@ import {
   $familiar,
   $item,
   $items,
+  $skill,
   $slot,
   $slots,
   BurningLeaves,
@@ -227,6 +229,41 @@ export function magnifyingGlass(): Map<Item, number> {
   ]);
 }
 
+function bindlestocking(mode: BonusEquipMode): Map<Item, number> {
+  // Requires a guaranteed critical hit that does not need the weapon or off-hand slots
+  // Only BARF is supported as it is difficult to always crit elsewhere
+  const canCrit =
+    (have($skill`Furious Wallop`) && myFury() > 0) ||
+    have($skill`Head in the Game`);
+  if (
+    !have($item`bindlestocking`) ||
+    mode !== BonusEquipMode.BARF ||
+    !canCrit
+  ) {
+    return new Map<Item, number>();
+  }
+
+  // TODO: Confirm drop rates with excavator https://excavator.loathers.net/projects/bindlestocking
+  // The only valuable items are fancy chocolate or jawbruiser which probably appear ~1% of the time
+  const value =
+    0.49 *
+      garboAverageValue(
+        ...$items`Angry Farmer candy, Cold Hots candy, Daffy Taffy, Mr. Mediocrebar, Senior Mints, Wint-O-Fresh mint, orange`,
+      ) +
+    0.15 * garboAverageValue(...$items`eggnog, fruitcake, yo-yo`) +
+    0.2 *
+      garboAverageValue(
+        ...$items`candy cane, ball, fancy dress ball, gingerbread bugbear, razor-tipped yo-yo`,
+      ) +
+    0.15 *
+      garboAverageValue(
+        ...$items`buckyball, gyroscope, monomolecular yo-yo, possessed top, top`,
+      ) +
+    0.01 * garboAverageValue(...$items`fancy chocolate, jawbruiser`);
+
+  return new Map<Item, number>([[$item`bindlestocking`, value]]);
+}
+
 export function bonusGear(
   mode: BonusEquipMode,
   valueCircumstantialBonus = true,
@@ -239,6 +276,7 @@ export function bonusGear(
     ...stickers(mode),
     ...powerGlove(),
     ...sneegleebs(),
+    ...bindlestocking(mode),
     ...(valueCircumstantialBonus
       ? new Map<Item, number>([
           ...pantsgiving(mode),


### PR DESCRIPTION
Unsure if the math will ever work out for this especially since it takes two slots but worth calculating. Pretty much limited to only seal clubbers as otherwise it is difficult to crit when the weapon and off-hand slots are used.

The wiki drop rates I sourced from are probably slightly off but all that really matters here is what appears to be a 1% combined drop rate for fancy chocolate and jawbruisers