### PR TITLE
More accurate Kiwi math

### DIFF
--- a/packages/garbo/src/familiar/constantValueFamiliars.ts
+++ b/packages/garbo/src/familiar/constantValueFamiliars.ts
@@ -111,7 +111,10 @@ const standardFamiliars: ConstantValueFamiliar[] = [
   },
   {
     familiar: $familiar`Mini Kiwi`,
-    value: () => 0.25 * garboValue($item`mini kiwi`), // faster with aviator goggles
+    value: () =>
+      (familiarWeight($familiar`Mini Kiwi`) + weightAdjustment()) *
+      0.005 *
+      garboValue($item`mini kiwi`), // faster with aviator goggles
   },
 ];
 

--- a/packages/garbo/src/outfit/dropsgear.ts
+++ b/packages/garbo/src/outfit/dropsgear.ts
@@ -1,5 +1,6 @@
 import {
   equippedItem,
+  familiarWeight,
   fullnessLimit,
   getWorkshed,
   haveEffect,
@@ -9,6 +10,7 @@ import {
   myFury,
   numericModifier,
   toSlot,
+  weightAdjustment,
 } from "kolmafia";
 import {
   $effect,
@@ -391,7 +393,10 @@ function aviatorGoggles(mode: BonusEquipMode): Map<Item, number> {
   if (mode === BonusEquipMode.EMBEZZLER || !have($familiar`Mini Kiwi`)) {
     return new Map();
   }
-  const goggleValue = garboValue($item`mini kiwi`) * 0.25;
+  const goggleValue =
+    garboValue($item`mini kiwi`) *
+    (familiarWeight($familiar`Mini Kiwi`) + weightAdjustment()) *
+    0.0025;
   return new Map<Item, number>([[$item`aviator goggles`, goggleValue]]);
 }
 


### PR DESCRIPTION
Used Excavator data to spade something closer to actual rates.

There may be more we still don't understand, but a 25% drop rate is simply inaccurate.