### PR TITLE
Add Spring Shoes as a pointer finger enabler; reduce value of Spring …

### DIFF
--- a/packages/garbo/src/outfit/barf.ts
+++ b/packages/garbo/src/outfit/barf.ts
@@ -97,6 +97,10 @@ const POINTER_RING_SPECS: (
   },
   {
     available: true,
+    items: $items`spring shoes, mafia pointer finger ring`,
+  },
+  {
+    available: true,
     items: $items`left bear arm, right bear arm, mafia pointer finger ring`,
   },
 ];

--- a/packages/garbo/src/outfit/dropsgearAccessories.ts
+++ b/packages/garbo/src/outfit/dropsgearAccessories.ts
@@ -90,6 +90,17 @@ function mrScreegesSpectacles() {
   return new Map<Item, number>([[$item`Mr. Screege's spectacles`, 180]]);
 }
 
+function springShoes() {
+  if (!have($item`spring shoes`)) {
+    return new Map<Item, number>([]);
+  }
+
+  // Items appear to be every 1/3 adventures
+  // All droppable items are mallmin
+  // Therefore, 33 meat is reasonable
+  return new Map<Item, number>([[$item`spring shoes`, 33]]);
+}
+
 function cinchoDeMayo(mode: BonusEquipMode) {
   if (
     !have($item`Cincho de Mayo`) ||
@@ -123,6 +134,7 @@ export function bonusAccessories(mode: BonusEquipMode): Map<Item, number> {
     ...luckyGoldRing(mode),
     ...mrCheengsSpectacles(),
     ...mrScreegesSpectacles(),
+    ...springShoes(),
     ...cinchoDeMayo(mode),
   ]);
 }
@@ -172,10 +184,15 @@ export function usingThumbRing(): boolean {
         have($item`haiku katana`) ||
         have($item`Operation Patriot Shield`) ||
         have($item`unwrapped knock-off retro superhero cape`) ||
-        have($item`left bear arm`) ||
-        have($skill`Head in the Game`))
+        have($item`left bear arm`))
     ) {
       accessoryValues.set($item`mafia pointer finger ring`, 500);
+    }
+    if (
+      have($item`mafia pointer finger ring`) &&
+      (have($skill`Head in the Game`) || have($item`spring shoes`))
+    ) {
+      accessoryValues.set($item`mafia pointer finger ring`, 500 * 0.65);
     }
     const bestAccessories = [...accessoryValues.entries()]
       .sort(([, aBonus], [, bBonus]) => bBonus - aBonus)

--- a/packages/garbo/src/outfit/dropsgearAccessories.ts
+++ b/packages/garbo/src/outfit/dropsgearAccessories.ts
@@ -187,8 +187,7 @@ export function usingThumbRing(): boolean {
         have($item`left bear arm`))
     ) {
       accessoryValues.set($item`mafia pointer finger ring`, 500);
-    }
-    if (
+    } else if (
       have($item`mafia pointer finger ring`) &&
       (have($skill`Head in the Game`) || have($item`spring shoes`))
     ) {


### PR DESCRIPTION
…Shoes and Head in the Game

Players have a "base" 15% crit rate, adding 50% brings that to 65%. For Head In The Game and Spring Shoes, this implies the value of Mafia Pointer Finger Ring should only be .65 * 500 rather than the full 500.

Additionally, added the (minor) value spring shoes add in drops to (maybe) make Spring Shoe crits viable for a That Guy (tm)