### PR TITLE
Check to avoid autumnaton maxBy on empty array error

### DIFF
--- a/packages/garbo/src/tasks/post/index.ts
+++ b/packages/garbo/src/tasks/post/index.ts
@@ -1,5 +1,6 @@
 import {
   adv1,
+  availableAmount,
   availableChoiceOptions,
   canAdventure,
   cliExecute,
@@ -207,6 +208,11 @@ function fallbot(): GarboPostTask {
       AutumnAton.sendTo(bestAutumnatonLocation);
     },
     available: () => AutumnAton.have(),
+    post: () => {
+      if (availableAmount($item`autumn-aton`) > 0) {
+        cliExecute("refresh inventory");
+      }
+    },
   };
 }
 

--- a/packages/garbo/src/tasks/post/index.ts
+++ b/packages/garbo/src/tasks/post/index.ts
@@ -1,6 +1,5 @@
 import {
   adv1,
-  availableAmount,
   availableChoiceOptions,
   canAdventure,
   cliExecute,
@@ -209,7 +208,7 @@ function fallbot(): GarboPostTask {
     },
     available: () => AutumnAton.have(),
     post: () => {
-      if (availableAmount($item`autumn-aton`) > 0) {
+      if (have($item`autumn-aton`)) {
         cliExecute("refresh inventory");
       }
     },


### PR DESCRIPTION
Sometimes mafia doesn't remove autumn-aton from inventory after sending it out. This check should avoid that.