### PR TITLE
Allow high vOA for nobarf

### DIFF
--- a/packages/garbo/src/index.ts
+++ b/packages/garbo/src/index.ts
@@ -249,6 +249,7 @@ export function main(argString = ""): void {
     throw `Your valueOfAdventure is set to ${globalOptions.prefs.valueOfAdventure}, which is too low for barf farming to be worthwhile. If you forgot to set it, use "set valueOfAdventure = XXXX" to set it to your marginal turn meat value.`;
   }
   if (
+    !globalOptions.nobarf &&
     globalOptions.prefs.valueOfAdventure &&
     globalOptions.prefs.valueOfAdventure >= 10000
   ) {


### PR DESCRIPTION
- **Check to avoid autumnaton maxBy on empty array error (#1972)**
- **use purple candle in meatKill too (#1973)**
- **remove jill from bestFairy (#1974)**
- **Allow arbitrarily high voa for nobarf**
