### PR TITLE
use Shadow Bricks for sandworms if profitable to do so

### DIFF
--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -22,6 +22,7 @@ import {
   isBanished,
   Item,
   itemAmount,
+  itemDropModifier,
   itemDropsArray,
   Location,
   mallPrice,
@@ -1915,6 +1916,36 @@ const freeKillSources = [
         Macro.trySingAlong()
           .tryHaveSkill($skill`Otoscope`)
           .skill($skill`Asdon Martin: Missile Launcher`),
+        () => use($item`drum machine`),
+      );
+    },
+    true,
+    {
+      spec: sandwormSpec,
+      effects: () =>
+        have($skill`Emotionally Chipped`) && get("_feelLostUsed") < 3
+          ? $effects`Feeling Lost`
+          : [],
+    },
+  ),
+
+  new FreeFight(
+    () =>
+      globalOptions.ascend &&
+      0.1 * garboValue($item`spice melange`) * itemDropModifier() >
+        garboValue($item`shadow brick`)
+        ? clamp(13 - get("_shadowBricksUsed"), 0, 13)
+        : 0,
+    () => {
+      ensureBeachAccess();
+      retrieveItem(
+        $item`shadow brick`,
+        clamp(13 - get("_shadowBricksUsed"), 0, 13),
+      );
+      withMacro(
+        Macro.trySingAlong()
+          .tryHaveSkill($skill`Otoscope`)
+          .tryItem($item`shadow brick`),
         () => use($item`drum machine`),
       );
     },

--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -22,7 +22,6 @@ import {
   isBanished,
   Item,
   itemAmount,
-  itemDropModifier,
   itemDropsArray,
   Location,
   mallPrice,
@@ -1932,8 +1931,8 @@ const freeKillSources = [
   new FreeFight(
     () =>
       globalOptions.ascend &&
-      0.1 * garboValue($item`spice melange`) * itemDropModifier() >
-        garboValue($item`shadow brick`)
+      0.1 * garboValue($item`spice melange`) * numericModifier("Item Drop %") >
+        mallPrice($item`shadow brick`)
         ? clamp(13 - get("_shadowBricksUsed"), 0, 13)
         : 0,
     () => {

--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -1931,7 +1931,9 @@ const freeKillSources = [
   new FreeFight(
     () =>
       globalOptions.ascend &&
-      0.1 * garboValue($item`spice melange`) * numericModifier("Item Drop %") >
+      0.1 *
+        garboValue($item`spice melange`) *
+        (numericModifier("Item Drop") / 100) >
         mallPrice($item`shadow brick`)
         ? clamp(13 - get("_shadowBricksUsed"), 0, 13)
         : 0,


### PR DESCRIPTION
The logic for when it's profitable may need work, as we're checking current item% modifier rather than first building a sandworm outfit. If there's a better way to do this, I'm open to it.