### PR TITLE
Add little red book, skip LTS for mimes

### DIFF
--- a/packages/garbo/src/combat.ts
+++ b/packages/garbo/src/combat.ts
@@ -606,20 +606,18 @@ export class Macro extends StrictMacro {
         myBuffedstat($stat`Muscle`) > myBuffedstat($stat`Mysticality`) &&
           (currentHitStat() === $stat`Muscle` ||
             itemType(equippedItem($slot`weapon`)) === "knife"),
-        Macro.trySkillRepeat(
-          $skill`Northern Explosion`,
-        )
-        .ifNot(
-          $monster`cheerless mime executive`,
-          Macro.trySkillRepeat($skill`Lunging Thrust-Smack`)
-        )
-        .trySkillRepeat(
-          $skill`Saucegeyser`,
-          $skill`Weapon of the Pastalord`,
-          $skill`Cannelloni Cannon`,
-          $skill`Wave of Sauce`,
-          $skill`Saucestorm`,
-        ),
+        Macro.trySkillRepeat($skill`Northern Explosion`)
+          .ifNot(
+            $monster`cheerless mime executive`,
+            Macro.trySkillRepeat($skill`Lunging Thrust-Smack`)
+          )
+          .trySkillRepeat(
+            $skill`Saucegeyser`,
+            $skill`Weapon of the Pastalord`,
+            $skill`Cannelloni Cannon`,
+            $skill`Wave of Sauce`,
+            $skill`Saucestorm`,
+          ),
         Macro.trySkillRepeat(
           $skill`Saucegeyser`,
           $skill`Weapon of the Pastalord`,

--- a/packages/garbo/src/combat.ts
+++ b/packages/garbo/src/combat.ts
@@ -609,7 +609,7 @@ export class Macro extends StrictMacro {
         Macro.trySkillRepeat($skill`Northern Explosion`)
           .ifNot(
             $monster`cheerless mime executive`,
-            Macro.trySkillRepeat($skill`Lunging Thrust-Smack`)
+            Macro.trySkillRepeat($skill`Lunging Thrust-Smack`),
           )
           .trySkillRepeat(
             $skill`Saucegeyser`,

--- a/packages/garbo/src/combat.ts
+++ b/packages/garbo/src/combat.ts
@@ -236,8 +236,9 @@ export class Macro extends StrictMacro {
       .tryHaveSkill($skill`Pocket Crumbs`)
       .tryHaveItem($item`train whistle`)
       .tryHaveSkill($skill`Entangling Noodles`)
-      .tryHaveItem($item`Rain-Doh indigo cup`)
-      .tryHaveItem($item`Rain-Doh blue balls`);
+      .tryHaveItem($item`little red book`)
+      .tryHaveItem($item`Rain-Doh blue balls`)
+      .tryHaveItem($item`Rain-Doh indigo cup`);
   }
 
   static delevel(): Macro {
@@ -607,7 +608,12 @@ export class Macro extends StrictMacro {
             itemType(equippedItem($slot`weapon`)) === "knife"),
         Macro.trySkillRepeat(
           $skill`Northern Explosion`,
-          $skill`Lunging Thrust-Smack`,
+        )
+        .ifNot(
+          $monster`cheerless mime executive`,
+          Macro.trySkillRepeat($skill`Lunging Thrust-Smack`)
+        )
+        .trySkillRepeat(
           $skill`Saucegeyser`,
           $skill`Weapon of the Pastalord`,
           $skill`Cannelloni Cannon`,


### PR DESCRIPTION
Little red book is another repeatable deleveler so may as well.

Apparently I'm not the only That Guy who lacks Northern Explosion, and the current `.kill()` logic for muscle > mysticality has LTS come up ahead of Saucegeyser, which is a problem for mimes. Try to circumvent that.