### PR TITLE
move `safeInterrupt` to `available`

### DIFF
--- a/packages/garbo/src/tasks/engine.ts
+++ b/packages/garbo/src/tasks/engine.ts
@@ -44,6 +44,7 @@ function logEmbezzler(encounterType: string) {
  */
 export class BaseGarboEngine extends Engine<never, GarboTask> {
   available(task: GarboTask): boolean {
+    safeInterrupt();
     const taskSober = undelay(task.sobriety);
     if (taskSober) {
       return (
@@ -68,7 +69,6 @@ export class BaseGarboEngine extends Engine<never, GarboTask> {
   }
 
   execute(task: GarboTask): void {
-    safeInterrupt();
     const spentTurns = totalTurnsPlayed();
     const duplicate = undelay(task.duplicate);
     const before = SourceTerminal.getSkills();


### PR DESCRIPTION
we rely on `postCombatActions` to `safeInterrupt` during many of our non-grimoirized sections of code; this will ensure that we can `safeInterrupt` even if we never select a task to execute.