### PR TITLE
use `flatMap(...)` over `map(...).flat()`

### DIFF
--- a/packages/garbo/src/combat.ts
+++ b/packages/garbo/src/combat.ts
@@ -147,9 +147,9 @@ export class Macro extends StrictMacro {
         Macro.externalIf(
           get("_spaceJellyfishDrops") < 5,
           Macro.if_(
-            $locations`Barf Mountain, Pirates of the Garbage Barges, Uncle Gator's Country Fun-Time Liquid Waste Sluice, The Toxic Teacups`
-              .map((l) => getMonsters(l))
-              .flat(),
+            $locations`Barf Mountain, Pirates of the Garbage Barges, Uncle Gator's Country Fun-Time Liquid Waste Sluice, The Toxic Teacups`.flatMap(
+              (l) => getMonsters(l),
+            ),
             Macro.trySkill($skill`Extract Jelly`),
           ),
           Macro.trySkill($skill`Extract Jelly`),

--- a/packages/garbo/src/potions.ts
+++ b/packages/garbo/src/potions.ts
@@ -115,13 +115,11 @@ const availableItems = [
   ...new Set(
     Location.all()
       .filter((l) => canAdventure(l))
-      .map((l) =>
+      .flatMap((l) =>
         getMonsters(l)
           .filter((m) => m.copyable)
-          .map((m) => itemDropsArray(m).filter(({ rate }) => rate > 1))
-          .flat(),
+          .flatMap((m) => itemDropsArray(m).filter(({ rate }) => rate > 1)),
       )
-      .flat()
       .map(({ drop }) => drop),
   ),
 ].map((i) => i.name);

--- a/packages/garbo/src/resources/autumnaton.ts
+++ b/packages/garbo/src/resources/autumnaton.ts
@@ -44,8 +44,7 @@ function averageAutumnatonValue(
     const maximumDrops = slotOverride ?? AutumnAton.zoneItems();
     const acuityCutoff = 20 - (acuityOverride ?? AutumnAton.visualAcuity()) * 5;
     const validDrops = monsters
-      .map((m) => itemDropsArray(m))
-      .flat()
+      .flatMap((m) => itemDropsArray(m))
       .map(({ rate, type, drop }) => ({
         value: !["c", "0"].includes(type) ? garboValue(drop) : 0,
         preAcuityExpectation: ["c", "0", ""].includes(type)

--- a/packages/garbo/src/resources/mayam.ts
+++ b/packages/garbo/src/resources/mayam.ts
@@ -4,7 +4,6 @@ import {
   $item,
   CinchoDeMayo,
   clamp,
-  flat,
   get,
   maxBy,
   MayamCalendar,
@@ -114,10 +113,8 @@ function expandCombinationGroup<N extends number>(
   MayamCalendar.CombinationString,
 ][] {
   const forbiddenSymbols = [
-    ...flat(
-      group.map((combinationString) =>
-        MayamCalendar.toCombination([combinationString]),
-      ),
+    ...group.flatMap((combinationString) =>
+      MayamCalendar.toCombination([combinationString]),
     ),
     ...MayamCalendar.symbolsUsed(),
   ];


### PR DESCRIPTION
Minor performance improvement, but one all the same.