### PR TITLE
only run `meatMood` every 11 turns, for speed reasons

### DIFF
--- a/packages/garbo/src/tasks/barfTurn.ts
+++ b/packages/garbo/src/tasks/barfTurn.ts
@@ -926,6 +926,7 @@ export const BarfTurnQuest: Quest<GarboTask> = {
       ),
       prepare: () =>
         get("dinseyRollercoasterNext") ||
+        !(totalTurnsPlayed() % 11) ||
         meatMood().execute(estimatedGarboTurns()),
       post: () => {
         completeBarfQuest();

--- a/packages/garbo/src/tasks/barfTurn.ts
+++ b/packages/garbo/src/tasks/barfTurn.ts
@@ -925,8 +925,8 @@ export const BarfTurnQuest: Quest<GarboTask> = {
           ).abort(),
       ),
       prepare: () =>
-        get("dinseyRollercoasterNext") ||
-        !(totalTurnsPlayed() % 11) ||
+        !get("dinseyRollercoasterNext") &&
+        !(totalTurnsPlayed() % 11) &&
         meatMood().execute(estimatedGarboTurns()),
       post: () => {
         completeBarfQuest();


### PR DESCRIPTION
I feel like garbo has gotten way slower, besides just diet, and I assume this is the culprit.