### PR TITLE
only try to emit drones if we have goose up

### DIFF
--- a/packages/garbo/src/combat.ts
+++ b/packages/garbo/src/combat.ts
@@ -740,7 +740,9 @@ export class Macro extends StrictMacro {
 
   tryDrone(): Macro {
     return this.externalIf(
-      gooseDroneEligible() && get("gooseDronesRemaining") < copyTargetCount(),
+      myFamiliar() === $familiar`Grey Goose` &&
+        gooseDroneEligible() &&
+        get("gooseDronesRemaining") < copyTargetCount(),
       Macro.if_(
         globalOptions.target,
         Macro.trySkill($skill`Emit Matter Duplicating Drones`),


### PR DESCRIPTION
I've noticed a significant slowdown this past week or so, looks like `copyTargetCount` includes a ponder pagehit and a pagehit examining mimic eggs. The former is cached and will happen at most once per combat (still v unnecessary) but the latter isn't and will potentially get hit a lot as a result. This'll make us not call `copyTargetCount` every barfTurn