### PR TITLE
Better Gooso 2 electric boogaloo

### DIFF
--- a/packages/garbo/src/familiar/constantValueFamiliars.ts
+++ b/packages/garbo/src/familiar/constantValueFamiliars.ts
@@ -17,7 +17,7 @@ import { GeneralFamiliar } from "./lib";
 
 type ConstantValueFamiliar = {
   familiar: Familiar;
-  value: (_mode: "barf" | "free") => number;
+  value: (_mode: "barf" | "free" | "target") => number;
 };
 
 const bestAlternative = getModifier("Meat Drop", $item`amulet coin`);
@@ -101,7 +101,7 @@ const standardFamiliars: ConstantValueFamiliar[] = [
 ];
 
 export default function getConstantValueFamiliars(
-  mode: "barf" | "free",
+  mode: "barf" | "free" | "target",
 ): GeneralFamiliar[] {
   return standardFamiliars
     .filter(({ familiar }) => have(familiar))

--- a/packages/garbo/src/familiar/experienceFamiliars.ts
+++ b/packages/garbo/src/familiar/experienceFamiliars.ts
@@ -15,16 +15,20 @@ import { mimicExperienceNeeded, shouldChargeMimic } from "../resources";
 
 type ExperienceFamiliar = {
   familiar: Familiar;
-  used: propertyTypes.BooleanProperty | ((mode: "barf" | "free") => boolean);
+  used:
+    | propertyTypes.BooleanProperty
+    | ((mode: "barf" | "free" | "target") => boolean);
   useValue: Delayed<number>;
   baseExp: number;
   xpCost?: number;
-  xpLimit?: (mode: "barf" | "free") => number;
+  xpLimit?: (mode: "barf" | "free" | "target") => number;
 };
 
 const isUsed = (
-  used: propertyTypes.BooleanProperty | ((mode: "barf" | "free") => boolean),
-  mode: "barf" | "free",
+  used:
+    | propertyTypes.BooleanProperty
+    | ((mode: "barf" | "free" | "target") => boolean),
+  mode: "barf" | "free" | "target",
 ) => (typeof used === "string" ? get(used) : used(mode));
 
 const experienceFamiliars: ExperienceFamiliar[] = [
@@ -42,17 +46,19 @@ const experienceFamiliars: ExperienceFamiliar[] = [
   },
   {
     familiar: $familiar`Chest Mimic`,
-    used: (mode: "barf" | "free") => !shouldChargeMimic(mode === "barf"),
+    used: (mode: "barf" | "free" | "target") =>
+      !shouldChargeMimic(mode === "barf"),
     useValue: () => MEAT_TARGET_MULTIPLIER() * get("valueOfAdventure"),
     baseExp: 0,
     xpCost: 50,
-    xpLimit: (mode: "barf" | "free") => mimicExperienceNeeded(mode === "barf"),
+    xpLimit: (mode: "barf" | "free" | "target") =>
+      mimicExperienceNeeded(mode === "barf"),
   },
 ];
 
 function valueExperienceFamiliar(
   { familiar, useValue, xpCost, baseExp }: ExperienceFamiliar,
-  mode: "barf" | "free",
+  mode: "barf" | "free" | "target",
 ): GeneralFamiliar {
   const currentExp =
     familiar.experience || (have($familiar`Shorter-Order Cook`) ? 100 : 0);
@@ -68,7 +74,7 @@ function valueExperienceFamiliar(
 }
 
 export default function getExperienceFamiliars(
-  mode: "barf" | "free",
+  mode: "barf" | "free" | "target",
 ): GeneralFamiliar[] {
   return experienceFamiliars
     .filter(

--- a/packages/garbo/src/familiar/freeFightFamiliar.ts
+++ b/packages/garbo/src/familiar/freeFightFamiliar.ts
@@ -32,7 +32,7 @@ type MenuOptions = Partial<{
   extraFamiliars: GeneralFamiliar[];
   includeExperienceFamiliars: boolean;
   allowAttackFamiliars: boolean;
-  mode: "barf" | "free";
+  mode: "barf" | "free" | "target";
 }>;
 const DEFAULT_MENU_OPTIONS = {
   canChooseMacro: true,
@@ -73,20 +73,20 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
     }
 
     if (
-      mode === "free" &&
+      mode === "target" &&
       gooseDroneEligible() &&
       get("gooseDronesRemaining") < copyTargetCount()
     ) {
       familiarMenu.push({
         familiar: $familiar`Grey Goose`,
         expectedValue:
-            // It takes 9 experience to go from level 5 to 6 and emit a drone
-            clamp(
-              getModifier("Familiar Experience") / 9,
-              0,
-              // The limit to how valuable any emission can be is how many drones are actually gonna hit the copyTarget
-              copyTargetCount() - get("gooseDronesRemaining"),
-            ) * valueDrops(globalOptions.target),
+          // It takes 9 experience to go from level 5 to 6 and emit a drone
+          clamp(
+            getModifier("Familiar Experience") / 9,
+            0,
+            // The limit to how valuable any emission can be is how many drones are actually gonna hit the copyTarget
+            copyTargetCount() - get("gooseDronesRemaining"),
+          ) * valueDrops(globalOptions.target),
         leprechaunMultiplier: 0,
         limit: "experience",
       });

--- a/packages/garbo/src/familiar/freeFightFamiliar.ts
+++ b/packages/garbo/src/familiar/freeFightFamiliar.ts
@@ -73,26 +73,24 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
     }
 
     if (
+      mode === "free" &&
       gooseDroneEligible() &&
       get("gooseDronesRemaining") < copyTargetCount()
     ) {
       familiarMenu.push({
         familiar: $familiar`Grey Goose`,
         expectedValue:
-          mode === "free"
-            ? // It takes 9 experience to go from level 5 to 6 and emit a drone
-              clamp(
-                getModifier("Familiar Experience") / 9,
-                0,
-                // The limit to how valuable any emission can be is how many drones are actually gonna hit the copyTarget
-                copyTargetCount() - get("gooseDronesRemaining"),
-              ) * valueDrops(globalOptions.target)
-            : 0,
+            // It takes 9 experience to go from level 5 to 6 and emit a drone
+            clamp(
+              getModifier("Familiar Experience") / 9,
+              0,
+              // The limit to how valuable any emission can be is how many drones are actually gonna hit the copyTarget
+              copyTargetCount() - get("gooseDronesRemaining"),
+            ) * valueDrops(globalOptions.target),
         leprechaunMultiplier: 0,
         limit: "experience",
       });
     }
-
     if (canOpenRedPresent()) {
       familiarMenu.push({
         familiar: $familiar`Crimbo Shrub`,

--- a/packages/garbo/src/familiar/freeFightFamiliar.ts
+++ b/packages/garbo/src/familiar/freeFightFamiliar.ts
@@ -79,13 +79,15 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
       familiarMenu.push({
         familiar: $familiar`Grey Goose`,
         expectedValue:
-          // It takes 9 experience to go from level 5 to 6 and emit a drone
-          clamp(
-            getModifier("Familiar Experience") / 9,
-            0,
-            // The limit to how valuable any emission can be is how many drones are actually gonna hit the copyTarget
-            copyTargetCount() - get("gooseDronesRemaining"),
-          ) * valueDrops(globalOptions.target),
+          mode === "free"
+            ? // It takes 9 experience to go from level 5 to 6 and emit a drone
+              clamp(
+                getModifier("Familiar Experience") / 9,
+                0,
+                // The limit to how valuable any emission can be is how many drones are actually gonna hit the copyTarget
+                copyTargetCount() - get("gooseDronesRemaining"),
+              ) * valueDrops(globalOptions.target)
+            : 0,
         leprechaunMultiplier: 0,
         limit: "experience",
       });

--- a/packages/garbo/src/familiar/freeFightFamiliar.ts
+++ b/packages/garbo/src/familiar/freeFightFamiliar.ts
@@ -12,6 +12,7 @@ import {
   clamp,
   findLeprechaunMultiplier,
   get,
+  getModifier,
   have,
 } from "libram";
 import { canOpenRedPresent } from ".";
@@ -21,6 +22,9 @@ import getDropFamiliars from "./dropFamiliars";
 import getExperienceFamiliars from "./experienceFamiliars";
 import { GeneralFamiliar, timeToMeatify } from "./lib";
 import { meatFamiliar } from "./meatFamiliar";
+import { gooseDroneEligible, valueDrops } from "../lib";
+import { globalOptions } from "../config";
+import { copyTargetCount } from "../target";
 
 type MenuOptions = Partial<{
   canChooseMacro: boolean;
@@ -63,6 +67,25 @@ export function menu(options: MenuOptions = {}): GeneralFamiliar[] {
         familiar: $familiar`Grey Goose`,
         expectedValue:
           (Math.max(familiarWeight($familiar`Grey Goose`) - 5), 0) ** 4,
+        leprechaunMultiplier: 0,
+        limit: "experience",
+      });
+    }
+
+    if (
+      gooseDroneEligible() &&
+      get("gooseDronesRemaining") < copyTargetCount()
+    ) {
+      familiarMenu.push({
+        familiar: $familiar`Grey Goose`,
+        expectedValue:
+          // It takes 9 experience to go from level 5 to 6 and emit a drone
+          clamp(
+            getModifier("Familiar Experience") / 9,
+            0,
+            // The limit to how valuable any emission can be is how many drones are actually gonna hit the copyTarget
+            copyTargetCount() - get("gooseDronesRemaining"),
+          ) * valueDrops(globalOptions.target),
         leprechaunMultiplier: 0,
         limit: "experience",
       });

--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -147,7 +147,6 @@ import {
   freeRest,
   freeRunConstraints,
   getUsingFreeBunnyBanish,
-  gooseDroneEligible,
   HIGHLIGHT,
   isFree,
   isFreeAndCopyable,
@@ -396,10 +395,6 @@ function familiarSpec(underwater: boolean, fight: string): OutfitSpec {
     if (have($familiar`Reanimated Reanimator`)) {
       return { familiar: $familiar`Reanimated Reanimator` };
     }
-  }
-
-  if (gooseDroneEligible() && get("gooseDronesRemaining") < copyTargetCount()) {
-    return { familiar: $familiar`Grey Goose` };
   }
 
   if (isFreeAndCopyable(globalOptions.target)) {

--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -398,7 +398,7 @@ function familiarSpec(underwater: boolean, fight: string): OutfitSpec {
   }
 
   if (isFreeAndCopyable(globalOptions.target)) {
-    return { familiar: freeFightFamiliar() };
+    return { familiar: freeFightFamiliar({ mode: "target" }) };
   }
 
   return { familiar: meatFamiliar() };

--- a/packages/garbo/src/lib.ts
+++ b/packages/garbo/src/lib.ts
@@ -198,10 +198,8 @@ export const gooseDroneEligible = () =>
   have($familiar`Grey Goose`);
 
 export function averageTargetNet(): number {
-  const goose = gooseDroneEligible() ? 2 : 1;
-
   return targettingItems()
-    ? valueDrops(globalOptions.target) * goose
+    ? valueDrops(globalOptions.target)
     : (targetMeat() * meatDropModifier()) / 100;
 }
 


### PR DESCRIPTION
Value drone emission as a free fight familiar; defer to Garbo math to determine when to emit drones vs use another free fight familiar.

Given the value of free copytargets is near mallmin (lol, lmao) we should probably only emit drones when the opportunity cost makes it make sense to do so.