### PR TITLE
feat: support workshed=takerspace

### DIFF
--- a/packages/garbo/src/config.ts
+++ b/packages/garbo/src/config.ts
@@ -10,7 +10,8 @@ const workshedAliases = [
   },
   { item: $item`Little Geneticist DNA-Splicing Lab`, aliases: ["dnalab"] },
 ];
-const unaliasedSheds = $items`cold medicine cabinet, diabolic pizza cube, portable Mayo Clinic, spinning wheel, warbear auto-anvil, warbear chemistry lab, warbear high-efficiency still, warbear induction oven, warbear jackhammer drill press, warbear LP-ROM burner`;
+// eslint-disable-next-line libram/verify-constants
+const unaliasedSheds = $items`TakerSpace letter of Marque, cold medicine cabinet, diabolic pizza cube, portable Mayo Clinic, spinning wheel, warbear auto-anvil, warbear chemistry lab, warbear high-efficiency still, warbear induction oven, warbear jackhammer drill press, warbear LP-ROM burner`;
 const allWorkshedAliases = [
   ...workshedAliases.map(({ item, aliases }) => {
     return { item: item, aliases: [...aliases, item.name.toLowerCase()] };

--- a/packages/garbo/src/index.ts
+++ b/packages/garbo/src/index.ts
@@ -117,7 +117,7 @@ function defaultTarget() {
 }
 
 export function main(argString = ""): void {
-  sinceKolmafiaRevision(28078); // track remaining bat wing skills
+  sinceKolmafiaRevision(28151); // detect TakerSpace + basic related functionality
   checkGithubVersion();
 
   // Hit up main.php to get out of easily escapable choices

--- a/packages/garbo/src/tasks/post/worksheds.ts
+++ b/packages/garbo/src/tasks/post/worksheds.ts
@@ -142,7 +142,8 @@ const worksheds = [
   ...$items`warbear chemistry lab, warbear LP-ROM burner`.map(
     (item) => new GarboWorkshed({ workshed: item, done: potionSetupCompleted }),
   ),
-  ...$items`snow machine, warbear jackhammer drill press, warbear auto-anvil`.map(
+  // eslint-disable-next-line libram/verify-constants
+  ...$items`TakerSpace letter of Marque, snow machine, warbear jackhammer drill press, warbear auto-anvil`.map(
     (item) => new GarboWorkshed({ workshed: item }),
   ),
 ];


### PR DESCRIPTION
There's no point keeping it active as visiting it once gets you the items, which happens when you visit the workshed, which is done when Mafia tries to figure out what workshed you have.

Ignore libram/verify-constants because TakerSpace isn't in there yet.