### PR TITLE
switch to using external `mall-check` script

### DIFF
--- a/packages/garbo/src/index.ts
+++ b/packages/garbo/src/index.ts
@@ -63,7 +63,6 @@ import { dailySetup } from "./dailies";
 import { nonOrganAdventures, runDiet } from "./diet";
 import { dailyFights, freeFights } from "./fights";
 import {
-  allMallPrices,
   bestJuneCleaverOption,
   checkGithubVersion,
   HIGHLIGHT,
@@ -136,7 +135,7 @@ export function main(argString = ""): void {
     );
   }
 
-  allMallPrices();
+  cliExecute("mallcheck.js");
 
   if (globalOptions.target === $monster.none) {
     globalOptions.target = defaultTarget();

--- a/packages/garbo/src/lib.ts
+++ b/packages/garbo/src/lib.ts
@@ -22,7 +22,6 @@ import {
   itemDropsArray,
   lastMonster,
   Location,
-  mallPrices,
   meatDropModifier,
   Monster,
   mpCost,
@@ -48,7 +47,6 @@ import {
   rollover,
   runChoice,
   runCombat,
-  sessionStorage,
   setLocation,
   Skill,
   soulsauceCost,
@@ -1057,14 +1055,6 @@ export function newarkValue(): number {
 
 export function candyFactoryValue(): number {
   return garboAverageValue(...getDropsList("trainset"));
-}
-
-export function allMallPrices() {
-  const today = todayToString();
-  if (sessionStorage.getItem("allpricedate") !== today) {
-    mallPrices("allitems");
-    sessionStorage.setItem("allpricedate", today);
-  }
 }
 
 export function aprilFoolsRufus() {

--- a/packages/garbo/static/dependencies.txt
+++ b/packages/garbo/static/dependencies.txt
@@ -6,3 +6,4 @@ github Ezandora/Gain
 github Loathing-Associates-Scripting-Society/KoL-MineVolcano
 github loathers/combo release
 github loathers/excavator release
+github loathers/mall-check


### PR DESCRIPTION
This lets us avoid redundant `mallPrices` calls across other scripts like crimbo, freecandy, etc