### PR TITLE
Support using walkie talkies for ghosts

### DIFF
--- a/packages/garbo/src/familiar/lib.ts
+++ b/packages/garbo/src/familiar/lib.ts
@@ -3,6 +3,7 @@ import {
   Familiar,
   familiarEquipment,
   inebrietyLimit,
+  mallPrice,
   myAdventures,
   myInebriety,
   totalTurnsPlayed,
@@ -58,9 +59,12 @@ export function timeToMeatify(): boolean {
     have($item`latte lovers member's mug`) &&
     get("latteModifier").split(",").includes("Meat Drop: 40");
 
-  const nextProtonicGhost = have($item`protonic accelerator pack`)
-    ? Math.max(1, get("nextParanormalActivity") - totalTurns)
-    : Infinity;
+  const nextProtonicGhost =
+    have($item`protonic accelerator pack`) ||
+    mallPrice($item`almost-dead walkie-talkie`) <
+      globalOptions.prefs.valueOfFreeFight
+      ? Math.max(1, get("nextParanormalActivity") - totalTurns)
+      : Infinity;
   const nextVoteMonster =
     have($item`"I Voted!" sticker`) && get("_voteFreeFights") < 3
       ? Math.max(0, ((totalTurns % 11) - 1) % 11)

--- a/packages/garbo/src/tasks/barfTurn.ts
+++ b/packages/garbo/src/tasks/barfTurn.ts
@@ -656,7 +656,9 @@ const BarfTurnTasks: GarboTask[] = [
       mallPrice($item`almost-dead walkie-talkie`) <
         globalOptions.prefs.valueOfFreeFight &&
       get("nextParanormalActivity") <= totalTurnsPlayed(),
-    completed: () => get("questPAGhost") === "started",
+    completed: () =>
+      have($item`protonic accelerator pack`) ||
+      get("questPAGhost") === "started",
     do: () => {
       if (
         acquire(

--- a/packages/garbo/src/tasks/barfTurn.ts
+++ b/packages/garbo/src/tasks/barfTurn.ts
@@ -651,9 +651,29 @@ const BarfTurnTasks: GarboTask[] = [
     ),
   },
   {
-    name: "Proton Ghost",
+    name: "Use Walkie Talkie for Ghost",
     ready: () =>
-      have($item`protonic accelerator pack`) && !!get("ghostLocation"),
+      mallPrice($item`almost-dead walkie-talkie`) <
+        globalOptions.prefs.valueOfFreeFight &&
+      get("nextParanormalActivity") <= totalTurnsPlayed(),
+    completed: () => get("questPAGhost") === "started",
+    do: () => {
+      if (
+        acquire(
+          1,
+          $item`almost-dead walkie-talkie`,
+          globalOptions.prefs.valueOfFreeFight,
+          false,
+        )
+      ) {
+        use($item`almost-dead walkie-talkie`);
+      }
+    },
+    spendsTurn: false,
+  },
+  {
+    name: "Proton Ghost",
+    ready: () => !!get("ghostLocation"),
     completed: () => get("questPAGhost") === "unstarted",
     do: () => get("ghostLocation") as Location,
     outfit: () =>
@@ -662,11 +682,17 @@ const BarfTurnTasks: GarboTask[] = [
           get("ghostLocation") === $location`The Icy Peak`
             ? ["Cold Resistance 5 min"]
             : [],
-        back: $item`protonic accelerator pack`,
+        back: have($item`protonic accelerator pack`)
+          ? $item`protonic accelerator pack`
+          : [],
       }),
     choices: () =>
       wanderer().getChoices(get("ghostLocation") ?? $location.none),
-    combat: new GarboStrategy(() => Macro.ghostBustin()),
+    combat: new GarboStrategy(() =>
+      have($item`protonic accelerator pack`)
+        ? Macro.ghostBustin()
+        : Macro.basicCombat(),
+    ),
     spendsTurn: false,
     // Ghost fights are currently hard
     // and they resist physical attacks!

--- a/packages/garbo/src/tasks/barfTurn.ts
+++ b/packages/garbo/src/tasks/barfTurn.ts
@@ -672,6 +672,7 @@ const BarfTurnTasks: GarboTask[] = [
       }
     },
     spendsTurn: false,
+    limit: { skip: 40 }, // Safeguard to avoid infinite loops if mallPrice can bug
   },
   {
     name: "Proton Ghost",

--- a/packages/garbo/src/tasks/daily.ts
+++ b/packages/garbo/src/tasks/daily.ts
@@ -833,7 +833,9 @@ const DailyTasks: GarboTask[] = [
       mallPrice($item`almost-dead walkie-talkie`) <
         globalOptions.prefs.valueOfFreeFight &&
       get("nextParanormalActivity") <= totalTurnsPlayed(),
-    completed: () => get("questPAGhost") === "started",
+    completed: () =>
+      have($item`protonic accelerator pack`) ||
+      get("questPAGhost") === "started",
     do: () => {
       if (
         acquire(

--- a/packages/garbo/src/tasks/daily.ts
+++ b/packages/garbo/src/tasks/daily.ts
@@ -31,6 +31,7 @@ import {
   retrieveItem,
   runChoice,
   toSlot,
+  totalTurnsPlayed,
   toUrl,
   use,
   visitUrl,
@@ -824,6 +825,27 @@ const DailyTasks: GarboTask[] = [
         (x) => <AcquireItem>{ item: x },
       ),
     outfit: { modifier: "disco style" },
+    spendsTurn: false,
+  },
+  {
+    name: "Use Walkie Talkie for Ghost",
+    ready: () =>
+      mallPrice($item`almost-dead walkie-talkie`) <
+        globalOptions.prefs.valueOfFreeFight &&
+      get("nextParanormalActivity") <= totalTurnsPlayed(),
+    completed: () => get("questPAGhost") === "started",
+    do: () => {
+      if (
+        acquire(
+          1,
+          $item`almost-dead walkie-talkie`,
+          globalOptions.prefs.valueOfFreeFight,
+          false,
+        )
+      ) {
+        use($item`almost-dead walkie-talkie`);
+      }
+    },
     spendsTurn: false,
   },
 ];

--- a/packages/garbo/src/tasks/freeFight.ts
+++ b/packages/garbo/src/tasks/freeFight.ts
@@ -209,16 +209,22 @@ const stunDurations = new Map<Skill | Item, Delayed<number>>([
 const FreeFightTasks: GarboFreeFightTask[] = [
   {
     name: $item`protonic accelerator pack`.name,
-    ready: () =>
-      have($item`protonic accelerator pack`) &&
-      get("questPAGhost") !== "unstarted" &&
-      get("ghostLocation") !== null,
+    ready: () => get("ghostLocation") !== null,
     completed: () => get("questPAGhost") === "unstarted",
     choices: () =>
       wanderer().getChoices(get("ghostLocation") ?? $location.none),
     do: () => get("ghostLocation") ?? $location.none,
-    combat: new GarboStrategy(() => Macro.ghostBustin()),
-    outfit: () => freeFightOutfit({ back: $item`protonic accelerator pack` }),
+    combat: new GarboStrategy(() =>
+      have($item`protonic accelerator pack`)
+        ? Macro.ghostBustin()
+        : Macro.basicCombat(),
+    ),
+    outfit: () =>
+      freeFightOutfit({
+        back: have($item`protonic accelerator pack`)
+          ? $item`protonic accelerator pack`
+          : [],
+      }),
     tentacle: true,
   },
   {


### PR DESCRIPTION
I put acquiring and using a walkie talkie for our `GarboFreeFightTasks` ghosts in our dailies rather than within that task to not explode the ready and completed conditions for the task, and to avoid aborting if the acquire fails during the prepare/acquire step.