### PR TITLE
Use correct libram method for peridot choice

### DIFF
--- a/packages/garbo-lib/src/wanderer/index.ts
+++ b/packages/garbo-lib/src/wanderer/index.ts
@@ -393,7 +393,7 @@ export class WandererManager {
       !(target instanceof Location) &&
       this.getTarget(target).peridotMonster !== $monster.none
     ) {
-      const peridotChoice = PeridotOfPeril.getChoiceProperty(
+      const peridotChoice = PeridotOfPeril.getChoiceObject(
         this.getTarget(target).peridotMonster,
       );
       const newChoices = Object.assign(peridotChoice, baseChoices);


### PR DESCRIPTION
[A change in libram 0.11.6](https://github.com/loathers/libram/commit/7cdcc9d9e61053564dd61b7087af5abec512af02 ) updated the method we need to use for peridot, so the recent upgrade to 0.11.6 broke us. This fixes that issue so peridot wanderers are succeeding again:
> [1052] The Haunted Nursery
Preference _perilLocations changed from 322,341,344 to 322,341,344,397
Took choice 1557/1: a creepy doll
choice.php?whichchoice=1557&option=1&bandersnatch=1550&pwd
Preference lastEncounter changed from garbage tourist to possessed toy chest
Encounter: possessed toy chest
Preference _lastCombatActions changed from sk7297;it1316;it1316;it1316;it1316;it1316;it1316;it1316;it1316;it1316;it1316;it1316;it1316;it1316;sk1032; to 
Round 0: zincaito wins initiative!
Preference cosmicBowlingBallReturnCombats changed from 30 to 29
Round 0: zincaito casts SPIT JURASSIC ACID!