### PR TITLE
egg donation tweaks

### DIFF
--- a/packages/garbo/src/tasks/freeEggDonation.ts
+++ b/packages/garbo/src/tasks/freeEggDonation.ts
@@ -224,6 +224,7 @@ export const FreeMimicEggDonationQuest: Delayed<Quest<GarboTask>> = () => ({
   ready: () =>
     globalOptions.prefs.beSelfish !== true &&
     ChestMimic.have() &&
-    CombatLoversLocket.have(),
+    CombatLoversLocket.have() &&
+    CombatLoversLocket.reminiscesLeft() > 0,
   completed: () => get("_mimicEggsDonated") >= 3,
 });

--- a/packages/garbo/src/tasks/freeEggDonation.ts
+++ b/packages/garbo/src/tasks/freeEggDonation.ts
@@ -112,6 +112,9 @@ function mimicEscape(): ActionSource | undefined {
         action.source === $skill`Snokebomb` && getUsingFreeBunnyBanish()
           ? $skill`Snokebomb`.timescast < 2
           : true,
+      maximumCost: () =>
+        globalOptions.prefs.valueOfAdventure ??
+        globalOptions.prefs.valueOfFreeFight,
     }) ?? undefined
   );
 }


### PR DESCRIPTION
* take eggnet priority into account for valuation
* delevel / stun monster if it scales or it's stronger than us
* allow using cheap unlimited sources to escape the fight
* don't do any of this logic if no reminisces left

Haven't tested this yet, will after rollover

Should help resolve #2511