### PR TITLE
Fixed freeRest() eternal loop, and returning true (success) when it failed to rest

### DIFF
--- a/packages/garbo/src/lib.ts
+++ b/packages/garbo/src/lib.ts
@@ -839,6 +839,16 @@ export function withLocation<T>(location: Location, action: () => T): T {
 export function freeRest(): boolean {
   if (get("timesRested") >= totalFreeRests()) return false;
 
+  const start = myFamiliar();
+
+  // Switch familiar first, a familiar may be granting max hp/mp
+  if (
+    have($familiar`Skeleton of Crimbo Past`) &&
+    get("_knuckleboneRests", 0) < 5
+  ) {
+    useFamiliar($familiar`Skeleton of Crimbo Past`);
+  }
+
   if (myHp() >= myMaxhp() && myMp() >= myMaxmp()) {
     if (acquire(1, $item`awful poetry journal`, 10000, false)) {
       use($item`awful poetry journal`);
@@ -853,19 +863,14 @@ export function freeRest(): boolean {
     }
   }
 
-  if (
-    have($familiar`Skeleton of Crimbo Past`) &&
-    get("_knuckleboneRests", 0) < 5
-  ) {
-    const start = myFamiliar();
-    useFamiliar($familiar`Skeleton of Crimbo Past`);
-    visitUrl("campground.php?action=rest");
-    useFamiliar(start);
-  } else {
-    visitUrl("campground.php?action=rest");
-  }
+  const timesRested = get("timesRested");
+  visitUrl("campground.php?action=rest");
 
-  return true;
+  if (start !== myFamiliar()) {
+    useFamiliar(start);
+  }
+  // Only return true when a rest was actually used
+  return timesRested < get("timesRested");
 }
 
 export function printEventLog(): void {


### PR DESCRIPTION
A user in a clan discord reported that garbo was trying to rest in their dwelling for the last three hours, upon looking into this issue I noticed the similarities it has with another issue I encountered in my own personal drama, where kolmafia failed to detect "Chilled in the bones" or whatever its called, and thus wanted to keep attempting the task over and over.

Why, for this case, the user was failing to rest, I was at first unsure, so I meditated on this issue and decided to look at what familiar was being switched, and indeed, it was this month's iotm, a familiar that grants bonus stats, switching away from that familiar would lower the max health and max moxie points or w/e its called, making them full hp/mp again when they try to rest with their new active familiar, the past of crimbos skeletons.

Then because they're now full hp and mp again with the reduced max hp/mp, they will fail to rest.

But that just highlights a larger issue.

The issue is that this function is returning true to say a rest was used, when there's no evidence that the rest was used. I could be wrong, but that preference looks like it should always be updated when we rest.

Indeed, this could enter a larger issue where the task being repeated still happens, but that sounds like an issue with the task. Unless, freeRest() is supposed to return true if there was a free rest available, not if there was a success? I'm not sure, it feels like we should be throwing an error instead. But I'm waxing long enough that I'm starting to feel tempted to write a chocolate cake recipe and add a "Jump to Recipe" button at the start of this.