### PR TITLE
Added a visit to the Speakeasy Pool Table if the player has access

### DIFF
--- a/packages/garbo/src/tasks/daily.ts
+++ b/packages/garbo/src/tasks/daily.ts
@@ -559,6 +559,15 @@ const DailyTasks: GarboTask[] = [
     spendsTurn: false,
   },
   {
+    name: "Speakeasy pool table",
+    ready: () => get("ownsSpeakeasy"),
+    completed: () => get("poolSkill") > 0,
+    do: () =>
+      visitUrl("place.php?whichplace=speakeasy&action=olivers_pooltable"),
+    outfit: { modifier: "Pool Skill" },
+    spendsTurn: false,
+  },
+  {
     name: "Clan pool table",
     ready: () => getClanLounge()["Clan pool table"] !== undefined,
     completed: () => get("_poolGames") >= 3,

--- a/packages/garbo/src/tasks/daily.ts
+++ b/packages/garbo/src/tasks/daily.ts
@@ -97,6 +97,7 @@ const retrieveItems = $items`Half a Purse, seal tooth, The Jokester's gun`;
 
 let latteRefreshed = false;
 let snojoConfigured = false;
+let speakeasyPoolTableVisited = false;
 
 // For this valuation, we are using the rough approximated value of different
 //   voting initiatives. They are relatively straghtforward:
@@ -561,9 +562,11 @@ const DailyTasks: GarboTask[] = [
   {
     name: "Speakeasy pool table",
     ready: () => get("ownsSpeakeasy"),
-    completed: () => get("poolSkill") > 0,
-    do: () =>
-      visitUrl("place.php?whichplace=speakeasy&action=olivers_pooltable"),
+    completed: () => speakeasyPoolTableVisited,
+    do: () => {
+      visitUrl("place.php?whichplace=speakeasy&action=olivers_pooltable");
+      speakeasyPoolTableVisited = true;
+    },
     outfit: { modifier: "Pool Skill" },
     spendsTurn: false,
   },


### PR DESCRIPTION
**Changes**
I noticed Garbo doesn't visit the Speakeasy Pool Table for its free daily meat. Added a check for access, and a Pool Skill maximizer to get the most meat out of it before visiting.

**Notes**
I've never added to a GitHub project before, and thought I'd try my hand at it with this as my first addition, especially since it's small and low stakes.

Let me know if there's anything wrong with it, or if there are any best practices I missed!