### PR TITLE
Value Portable Laughing Stock

### DIFF
--- a/packages/eslint-config-garbo/index.mts
+++ b/packages/eslint-config-garbo/index.mts
@@ -4,7 +4,7 @@ import prettier from "eslint-config-prettier";
 import libram, { verifyConstantsSinceRevision } from "eslint-plugin-libram";
 import { defineConfig } from "eslint/config";
 
-const VERIFY_CONSTANTS_SINCE = 28970;
+const VERIFY_CONSTANTS_SINCE = 29130;
 
 /**
  * Base ruleset that projects can extend.

--- a/packages/garbo/src/outfit/dropsgearAccessories.ts
+++ b/packages/garbo/src/outfit/dropsgearAccessories.ts
@@ -157,8 +157,8 @@ function calculateLaughingStockBonus() {
 
   const fruitsDropped = get("_laughingStockFruitDropped", 0);
 
-  // if we have more than 11 fruit drops, it's a 1/50 chance, split to 1/10 classic and 9/10 basic
-  if (fruitsDropped > 11) {
+  // if we have 11 fruit drops, it's a 1/50 chance, split to 1/10 classic and 9/10 basic
+  if (fruitsDropped >= 11) {
     return 0.02 * (0.1 * classicFruitValue + 0.9 * basicFruitValue);
   }
   // otherwise it's seeded, but we are guaranteed at least 3 classic drops in 9 fights

--- a/packages/garbo/src/outfit/dropsgearAccessories.ts
+++ b/packages/garbo/src/outfit/dropsgearAccessories.ts
@@ -10,6 +10,7 @@ import {
 import {
   $class,
   $item,
+  $items,
   $location,
   $skill,
   $slot,
@@ -32,7 +33,7 @@ import {
 } from "../lib";
 import { maximumPinataCasts } from "../resources";
 import { globalOptions } from "../config";
-import { garboValue } from "../garboValue";
+import { garboAverageValue, garboValue } from "../garboValue";
 
 function mafiaThumbRing(mode: BonusEquipMode) {
   if (!have($item`mafia thumb ring`) || modeIsFree(mode)) {
@@ -146,6 +147,37 @@ function cinchoDeMayo(mode: BonusEquipMode) {
   return new Map<Item, number>([[$item`Cincho de Mayo`, 3 * felizValue()]]);
 }
 
+function calculateLaughingStockBonus() {
+  const basicFruitValue = garboAverageValue(
+    ...$items`orange, grapefruit, grapes, lemon, lime, papaya, cranberries, strawberry, cherry, kumquat, tangerine, raspberry, kiwi, blackberry, banana, cactus fruit, plum, pear, peach`,
+  );
+  const classicFruitValue = garboAverageValue(
+    ...$items`classic banana, antique watermelon, quince`,
+  );
+
+  const fruitsDropped = get("_laughingStockFruitDropped", 0);
+
+  // if we have more than 11 fruit drops, it's a 1/50 chance, split to 1/10 classic and 9/10 basic
+  if (fruitsDropped > 11) {
+    return 0.02 * (0.1 * classicFruitValue + 0.9 * basicFruitValue);
+  }
+  // otherwise it's seeded, but we are guaranteed at least 3 classic drops in 9 fights
+  // and otherwise it's a 1/10 chance of being special
+  return (3.8 * classicFruitValue + 7.2 * basicFruitValue) / 11;
+}
+
+function portableLaughingStock() {
+  if (!have($item`Portable Laughing Stock`)) {
+    return new Map<Item, number>([]);
+  }
+
+  const laughingStockBonus = calculateLaughingStockBonus();
+
+  return new Map<Item, number>([
+    [$item`Portable Laughing Stock`, laughingStockBonus],
+  ]);
+}
+
 /*
 This is separate from bonusGear to prevent circular references
 bonusGear() calls pantsgiving(), which calls estimatedGarboTurns(), which calls usingThumbRing()
@@ -156,6 +188,7 @@ export function bonusAccessories(mode: BonusEquipMode): Map<Item, number> {
     ...mafiaThumbRing(mode),
     ...luckyGoldRing(mode),
     ...mrCheengsSpectacles(),
+    ...portableLaughingStock(),
     ...mrScreegesSpectacles(),
     ...cinchoDeMayo(mode),
   ]);

--- a/packages/garbo/src/outfit/dropsgearAccessories.ts
+++ b/packages/garbo/src/outfit/dropsgearAccessories.ts
@@ -163,7 +163,8 @@ function calculateLaughingStockBonus() {
   }
   // otherwise it's seeded, but we are guaranteed at least 3 classic drops in 9 fights
   // and otherwise it's a 1/10 chance of being special
-  return (3.8 * classicFruitValue + 7.2 * basicFruitValue) / 11;
+  // it takes 56 turns to get all the fruit
+  return (3.8 * classicFruitValue + 7.2 * basicFruitValue) / 56;
 }
 
 function portableLaughingStock() {


### PR DESCRIPTION
Split the value between the initial 56 turns (11 drops) and the later turns.

A better valuation would consider each drop independently, but this is good enough and still equips at the moment.