### PR TITLE
Maximize MP after PirateRealm setup

### DIFF
--- a/packages/garbo/src/index.ts
+++ b/packages/garbo/src/index.ts
@@ -564,6 +564,7 @@ export function main(argString = ""): void {
           withProperty("removeMalignantEffects", false, () =>
             runGarboQuests([CockroachSetup]),
           );
+	maximize("MP", false);
         }
         // 0. diet stuff.
         if (


### PR DESCRIPTION
Maximize MP after CockroachSetup finishes and pointing to Trash Island before buffing.

This prevents the PirateRealm outfit from leaving the player with a low maximum MP when Garbo begins buffing.

Closes #2652.