### PR TITLE
Ranch refurbishing

### DIFF
--- a/packages/garbo-lib/src/wanderer/bofa.ts
+++ b/packages/garbo-lib/src/wanderer/bofa.ts
@@ -40,7 +40,7 @@ export function bofaFactory(
     const validLocations = Location.all().filter(
       (location) =>
         canWander(location, "yellow ray") &&
-        canAdventureOrUnlock(location) &&
+        canAdventureOrUnlock(location, true, options.underwaterAllowed) &&
         !locationSkiplist.includes(location),
     );
     return [...validLocations].map((l: Location) => {

--- a/packages/garbo-lib/src/wanderer/guzzlr.ts
+++ b/packages/garbo-lib/src/wanderer/guzzlr.ts
@@ -34,7 +34,7 @@ function considerAbandon(
     // consider abandoning
     (!location || // if mafia failed to track the location correctly
       locationSkiplist.includes(location) ||
-      !canAdventureOrUnlock(location) || // or the zone is marked as "generally cannot adv"
+      !canAdventureOrUnlock(location, true, options.underwaterAllowed) || // or the zone is marked as "generally cannot adv"
       (options.ascend &&
         wandererTurnsAvailableToday(options, location, true) < remaningTurns)) // or ascending and not enough turns to finish
   ) {

--- a/packages/garbo-lib/src/wanderer/index.ts
+++ b/packages/garbo-lib/src/wanderer/index.ts
@@ -38,6 +38,7 @@ import {
   DraggableFight,
   ensureMapElement,
   isDraggableFight,
+  underwater,
   unlock,
   UNPERIDOTABLE_MONSTERS,
   unperidotableZones,
@@ -291,7 +292,11 @@ function wanderWhere(
   const failed = candidate.targets.filter((target) => !target.prepareTurn());
 
   const badLocation =
-    !canAdventureOrUnlock(candidate.location) ||
+    !canAdventureOrUnlock(
+      candidate.location,
+      true,
+      options.underwaterAllowed,
+    ) ||
     !unlock(candidate.location, candidate.value) ||
     !canWander(candidate.location, type)
       ? [candidate.location]

--- a/packages/garbo-lib/src/wanderer/index.ts
+++ b/packages/garbo-lib/src/wanderer/index.ts
@@ -53,6 +53,8 @@ import { gingerbreadFactory } from "./gingerbreadcity";
 import { ultraRareFactory } from "./ultrarare";
 import { cookbookbatQuestFactory } from "./cookbookbatquest";
 import { bofaFactory } from "./bofa";
+import { pearlFactory } from "./pearl";
+import { yachtzeeFactory } from "./yachtzee";
 
 export type { DraggableFight };
 
@@ -73,6 +75,8 @@ const wanderFactories: WandererFactory[] = [
   ultraRareFactory,
   cookbookbatQuestFactory,
   bofaFactory,
+  pearlFactory,
+  yachtzeeFactory,
 ];
 
 function zoneAverageMonsterValue(
@@ -431,6 +435,29 @@ export class WandererManager {
     [$location`The Skeleton Store`, { 1060: 5 }],
     [$location`The Overgrown Lot`, { 1062: 7 }],
     [$location`The Haunted Billiards Room`, { 1436: 2, 875: 3 }], // Hustle away from the ghost
+    [$location`The Wreck of the Edgar Fitzsimmons`, { 299: 2 }], // Skip Hatch
+    [$location`An Octopus's Garden`, { 298: 2 }], // Skip Garden
+    [$location`Madness Reef`, { 311: 2 }], // Skip Trading scales TODO handle value trading
+    [
+      $location`The Dive Bar`,
+      (options, valueOfTurn) => {
+        return {
+          309: options.itemValue($item`seaode`) > valueOfTurn ? 1 : 2,
+        };
+      },
+    ],
+    [
+      $location`The Marinara Trench`,
+      (options, valueOfTurn) => {
+        return {
+          304:
+            options.itemValue($item`bubbling tempura batter`) > valueOfTurn
+              ? 1
+              : 2,
+          305: 2, // Skip globes of deep sauce
+        };
+      },
+    ],
   ]);
   equipment = new Map<Location, Item[]>([
     ...Location.all()

--- a/packages/garbo-lib/src/wanderer/index.ts
+++ b/packages/garbo-lib/src/wanderer/index.ts
@@ -38,7 +38,6 @@ import {
   DraggableFight,
   ensureMapElement,
   isDraggableFight,
-  underwater,
   unlock,
   UNPERIDOTABLE_MONSTERS,
   unperidotableZones,

--- a/packages/garbo-lib/src/wanderer/itemdrop.ts
+++ b/packages/garbo-lib/src/wanderer/itemdrop.ts
@@ -68,7 +68,7 @@ export function itemDropFactory(
     const validLocations = Location.all().filter(
       (location) =>
         canWander(location, "yellow ray") &&
-        canAdventureOrUnlock(location) &&
+        canAdventureOrUnlock(location, true, options.underwaterAllowed) &&
         !locationSkiplist.includes(location),
     );
     return [...validLocations].map((l: Location) => {

--- a/packages/garbo-lib/src/wanderer/lib.ts
+++ b/packages/garbo-lib/src/wanderer/lib.ts
@@ -141,9 +141,9 @@ const ILLEGAL_PARENTS = [
   "A Monorail Station",
   "Memories",
 ];
-const ILLEGAL_ZONES = ["The Drip", "Suburbs"];
+const ILLEGAL_ZONES = ["The Drip", "Suburbs", "The Mer-Kin Deepcity"];
 const canAdventureOrUnlockSkipList = [
-  ...$locations`The Bubblin' Caldera, Barrrney's Barrr, The F'c'le, The Poop Deck, Belowdecks, The Secret Government Laboratory, The Dire Warren, Inside the Palindome, The Haiku Dungeon, An Incredibly Strange Place (Bad Trip), An Incredibly Strange Place (Mediocre Trip), An Incredibly Strange Place (Great Trip), El Vibrato Island, The Daily Dungeon, Trick-or-Treating, Seaside Megalopolis, The Orcish Frat House, Through the Spacegate, Mt. Molehill`,
+  ...$locations`The Skate Park, The Bubblin' Caldera, Barrrney's Barrr, The F'c'le, The Poop Deck, Belowdecks, The Secret Government Laboratory, The Dire Warren, Inside the Palindome, The Haiku Dungeon, An Incredibly Strange Place (Bad Trip), An Incredibly Strange Place (Mediocre Trip), An Incredibly Strange Place (Great Trip), El Vibrato Island, The Daily Dungeon, Trick-or-Treating, Seaside Megalopolis, The Orcish Frat House, Through the Spacegate, Mt. Molehill`,
   ...Location.all().filter(
     ({ parent, zone }) =>
       ILLEGAL_PARENTS.includes(parent) || ILLEGAL_ZONES.includes(zone),
@@ -188,7 +188,7 @@ export function canAdventureOrUnlock(
       (z) => loc.zone === z.zone && (z.available() || !z.noInv),
     );
   return (
-    !underwater(loc) &&
+    (!underwater(loc) || have($effect`Fishy`)) && // Can we check from wanderer somehow whether our farming strategy is an underwater zone?
     !skiplist.includes(loc) &&
     (canAdventure(loc) || canUnlock)
   );

--- a/packages/garbo-lib/src/wanderer/lib.ts
+++ b/packages/garbo-lib/src/wanderer/lib.ts
@@ -70,6 +70,7 @@ export type WandererFactoryOptions = {
   valueOfAdventure?: number;
   takeTurnForProfit?: boolean;
   canRefractedGaze?: boolean;
+  underwaterAllowed?: boolean;
 };
 
 export type WandererFactory = (
@@ -152,6 +153,7 @@ const canAdventureOrUnlockSkipList = [
 export function canAdventureOrUnlock(
   loc: Location,
   includeUnlockable = true,
+  underwaterAllowed = false,
 ): boolean {
   const skiplist = [...canAdventureOrUnlockSkipList];
 
@@ -188,7 +190,7 @@ export function canAdventureOrUnlock(
       (z) => loc.zone === z.zone && (z.available() || !z.noInv),
     );
   return (
-    (!underwater(loc) || have($effect`Fishy`)) && // Can we check from wanderer somehow whether our farming strategy is an underwater zone?
+    (!underwater(loc) || (have($effect`Fishy`) && underwaterAllowed)) &&
     !skiplist.includes(loc) &&
     (canAdventure(loc) || canUnlock)
   );

--- a/packages/garbo-lib/src/wanderer/pearl.ts
+++ b/packages/garbo-lib/src/wanderer/pearl.ts
@@ -5,12 +5,21 @@ import {
   WandererTarget,
   wandererTurnsAvailableToday,
 } from "./lib";
-import { $effect, $element, $item, $location, get, have } from "libram";
+import {
+  $effect,
+  $element,
+  $item,
+  $location,
+  BooleanProperty,
+  get,
+  have,
+  NumericProperty,
+} from "libram";
 
 type PearlTarget = {
   location: Location;
-  completionPref: string;
-  progressPref: string;
+  completionPref: BooleanProperty;
+  progressPref: NumericProperty;
   estimatedProgress: number;
   maximizeElement: Element;
 };

--- a/packages/garbo-lib/src/wanderer/pearl.ts
+++ b/packages/garbo-lib/src/wanderer/pearl.ts
@@ -1,11 +1,11 @@
-import { Element, Location, numericModifier } from "kolmafia";
+import { Element, Location } from "kolmafia";
 import {
   DraggableFight,
   WandererFactoryOptions,
   WandererTarget,
   wandererTurnsAvailableToday,
 } from "./lib";
-import { $effect, $element, $item, $location, $modifier, get, have } from "libram";
+import { $effect, $element, $item, $location, get, have } from "libram";
 
 type PearlTarget = {
   location: Location;
@@ -22,40 +22,40 @@ const PearlTargets: PearlTarget[] = [
     completionPref: "_unblemishedPearlTheBriniestDeepests",
     progressPref: "_unblemishedPearlTheBriniestDeepestsProgress",
     estimatedProgress: 3.3,
-    maximizeElement: $element`Cold`
+    maximizeElement: $element`Cold`,
   },
   {
     location: $location`Madness Reef`,
     completionPref: "_unblemishedPearlMadnessReef",
     progressPref: "_unblemishedPearlMadnessReefProgress",
     estimatedProgress: 3.3,
-    maximizeElement: $element`Stench`
+    maximizeElement: $element`Stench`,
   },
   {
     location: $location`Anemone Mine`,
     completionPref: "_unblemishedPearlAnemoneMine",
     progressPref: "_unblemishedPearlAnemoneMineProgress",
     estimatedProgress: 3.3,
-    maximizeElement: $element`Spooky`
+    maximizeElement: $element`Spooky`,
   },
   {
     location: $location`The Dive Bar`,
     completionPref: "_unblemishedPearlDiveBar",
     progressPref: "_unblemishedPearlDiveBarProgress",
     estimatedProgress: 3.3,
-    maximizeElement: $element`Sleaze`
+    maximizeElement: $element`Sleaze`,
   },
   {
     location: $location`The Marinara Trench`,
     completionPref: "_unblemishedPearlMarinaraTrench",
     progressPref: "_unblemishedPearlMarinaraTrenchProgress",
     estimatedProgress: 3.3,
-    maximizeElement: $element`Hot`
+    maximizeElement: $element`Hot`,
   },
 ];
 
 // We need to throw this to the maximizer somehow so that we properly value elemental bonuses
-function elementalBonus(element: Element): number {
+/* function elementalBonus(element: Element): number {
   const resistance = numericModifier(
     $modifier`${element.toString()} Resistance`
   );
@@ -67,7 +67,7 @@ function elementalBonus(element: Element): number {
     Math.ceil(1 / progress(resistance));
 
   return get("valueOfAdventure", 4000) * (turns(resistance) - turns(resistance + 1));
-}
+} */
 
 function turnsRemainingToComplete(
   progressPref: string,

--- a/packages/garbo-lib/src/wanderer/pearl.ts
+++ b/packages/garbo-lib/src/wanderer/pearl.ts
@@ -1,0 +1,82 @@
+import { Location } from "kolmafia";
+import {
+  DraggableFight,
+  WandererFactoryOptions,
+  WandererTarget,
+  wandererTurnsAvailableToday,
+} from "./lib";
+import { $effect, $item, $location, get, have } from "libram";
+
+type PearlTarget = {
+  location: Location;
+  completionPref: string;
+  progressPref: string;
+  estimatedProgress: number;
+};
+const PearlTargets: PearlTarget[] = [
+  // estimating progress at some lower rates, 3.3 is with just passives.
+  // TODO value resistances when targeting these, maybe make a pref or something that records our expected amount?
+  {
+    location: $location`The Briniest Deepests`,
+    completionPref: "_unblemishedPearlTheBriniestDeepests",
+    progressPref: "_unblemishedPearlTheBriniestDeepestsProgress",
+    estimatedProgress: 3.3,
+  },
+  {
+    location: $location`Madness Reef`,
+    completionPref: "_unblemishedPearlMadnessReef",
+    progressPref: "_unblemishedPearlMadnessReefProgress",
+    estimatedProgress: 3.3,
+  },
+  {
+    location: $location`Anemone Mine`,
+    completionPref: "_unblemishedPearlAnemoneMine",
+    progressPref: "_unblemishedPearlAnemoneMineProgress",
+    estimatedProgress: 3.3,
+  },
+  {
+    location: $location`The Dive Bar`,
+    completionPref: "_unblemishedPearlDiveBar",
+    progressPref: "_unblemishedPearlDiveBarProgress",
+    estimatedProgress: 3.3,
+  },
+  {
+    location: $location`The Marinara Trench`,
+    completionPref: "_unblemishedPearlMarinaraTrench",
+    progressPref: "_unblemishedPearlMarinaraTrenchProgress",
+    estimatedProgress: 3.3,
+  },
+];
+
+function turnsRemainingToComplete(
+  progressPref: string,
+  estimatedProgress: number,
+) {
+  const progressRemaining = 100 - get(progressPref, 0);
+  return Math.ceil(progressRemaining / estimatedProgress);
+}
+
+export function pearlFactory(
+  type: DraggableFight,
+  _locationSkiplist: Location[],
+  options: WandererFactoryOptions,
+): WandererTarget[] {
+  if (have($effect`Fishy`) && type !== "freerun") {
+    return PearlTargets.filter(
+      (t) =>
+        !get(t.completionPref) &&
+        wandererTurnsAvailableToday(options, t.location, true) >=
+          turnsRemainingToComplete(t.progressPref, t.estimatedProgress),
+    ).map(
+      (t) =>
+        new WandererTarget({
+          name: `${t.location} Pearl`,
+          location: t.location,
+          zoneValue:
+            options.itemValue($item`unblemished pearl`) *
+            (t.estimatedProgress / 100),
+        }),
+    );
+  }
+  return [];
+}

--- a/packages/garbo-lib/src/wanderer/pearl.ts
+++ b/packages/garbo-lib/src/wanderer/pearl.ts
@@ -1,17 +1,18 @@
-import { Location } from "kolmafia";
+import { Element, Location, numericModifier } from "kolmafia";
 import {
   DraggableFight,
   WandererFactoryOptions,
   WandererTarget,
   wandererTurnsAvailableToday,
 } from "./lib";
-import { $effect, $item, $location, get, have } from "libram";
+import { $effect, $element, $item, $location, $modifier, get, have } from "libram";
 
 type PearlTarget = {
   location: Location;
   completionPref: string;
   progressPref: string;
   estimatedProgress: number;
+  maximizeElement: Element;
 };
 const PearlTargets: PearlTarget[] = [
   // estimating progress at some lower rates, 3.3 is with just passives.
@@ -21,32 +22,52 @@ const PearlTargets: PearlTarget[] = [
     completionPref: "_unblemishedPearlTheBriniestDeepests",
     progressPref: "_unblemishedPearlTheBriniestDeepestsProgress",
     estimatedProgress: 3.3,
+    maximizeElement: $element`Cold`
   },
   {
     location: $location`Madness Reef`,
     completionPref: "_unblemishedPearlMadnessReef",
     progressPref: "_unblemishedPearlMadnessReefProgress",
     estimatedProgress: 3.3,
+    maximizeElement: $element`Stench`
   },
   {
     location: $location`Anemone Mine`,
     completionPref: "_unblemishedPearlAnemoneMine",
     progressPref: "_unblemishedPearlAnemoneMineProgress",
     estimatedProgress: 3.3,
+    maximizeElement: $element`Spooky`
   },
   {
     location: $location`The Dive Bar`,
     completionPref: "_unblemishedPearlDiveBar",
     progressPref: "_unblemishedPearlDiveBarProgress",
     estimatedProgress: 3.3,
+    maximizeElement: $element`Sleaze`
   },
   {
     location: $location`The Marinara Trench`,
     completionPref: "_unblemishedPearlMarinaraTrench",
     progressPref: "_unblemishedPearlMarinaraTrenchProgress",
     estimatedProgress: 3.3,
+    maximizeElement: $element`Hot`
   },
 ];
+
+// We need to throw this to the maximizer somehow so that we properly value elemental bonuses
+function elementalBonus(element: Element): number {
+  const resistance = numericModifier(
+    $modifier`${element.toString()} Resistance`
+  );
+
+  const progress = (resistance: number) =>
+    Math.min(0.1, Math.max(0.017, 0.017 * Math.floor(resistance / 3)));
+
+  const turns = (resistance: number) =>
+    Math.ceil(1 / progress(resistance));
+
+  return get("valueOfAdventure", 4000) * (turns(resistance) - turns(resistance + 1));
+}
 
 function turnsRemainingToComplete(
   progressPref: string,

--- a/packages/garbo-lib/src/wanderer/yachtzee.ts
+++ b/packages/garbo-lib/src/wanderer/yachtzee.ts
@@ -1,0 +1,48 @@
+import { Location } from "kolmafia";
+import { $effect, $location, get, have, realmAvailable } from "libram";
+import {
+  DraggableFight,
+  WandererFactoryOptions,
+  WandererTarget,
+  wandererTurnsAvailableToday,
+} from "./lib";
+
+export function yachtzeeFactory(
+  type: DraggableFight,
+  locationSkiplist: Location[],
+  options: WandererFactoryOptions,
+): WandererTarget[] {
+  if (
+    realmAvailable("sleaze") &&
+    have($effect`Fishy`) &&
+    get("encountersUntilYachtzeeChoice") !== 0 &&
+    [
+      "backup",
+      "wanderer",
+      "yellow ray",
+      "freefight",
+      "freerun",
+      "conditional freefight",
+      "freefight (no items)",
+    ].includes(type) &&
+    !locationSkiplist.includes($location`The Sunken Party Yacht`)
+  ) {
+    const canFinishDelay =
+      wandererTurnsAvailableToday(
+        options,
+        $location`The Sunken Party Yacht`,
+        false,
+      ) > get("encountersUntilYachtzeeChoice");
+    return [
+      new WandererTarget({
+        name: "Yachtzee Countdown",
+        location: $location`The Sunken Party Yacht`,
+        zoneValue:
+          options.ascend && !canFinishDelay // If we're ascending and don't have wanderer turns to finish delay, just use fallback value
+            ? 20
+            : (20000 - get("valueOfAdventure")) / 19,
+      }),
+    ];
+  }
+  return [];
+}

--- a/packages/garbo/src/combat.ts
+++ b/packages/garbo/src/combat.ts
@@ -71,6 +71,7 @@ import { copyTargetCount } from "./target";
 import { garboValue } from "./garboValue";
 import { maximumPinataCasts, safeRefractedCasts } from "./resources";
 import { FarmingStrategy } from "./farmingStrategy";
+import { BanishMethod } from "./resources/banish";
 
 export function shouldRedigitize(): boolean {
   if (!SourceTerminal.have() || !SourceTerminal.canDigitize()) return false;
@@ -950,6 +951,11 @@ export class Macro extends StrictMacro {
 
   static refractedGaze(): Macro {
     return new Macro().duplicate();
+  }
+
+  farmingBanish(banish: BanishMethod | null): Macro {
+    if (!banish) return this;
+    return this.if_(FarmingStrategy.banishMonsters, banish.macro);
   }
 }
 

--- a/packages/garbo/src/combat.ts
+++ b/packages/garbo/src/combat.ts
@@ -954,7 +954,7 @@ export class Macro extends StrictMacro {
   }
 
   farmingBanish(banish: BanishMethod | null): Macro {
-    if (!banish) return this;
+    if (!banish || !FarmingStrategy.banishMonsters.length) return this;
     return this.if_(FarmingStrategy.banishMonsters, banish.macro);
   }
 }

--- a/packages/garbo/src/config.ts
+++ b/packages/garbo/src/config.ts
@@ -277,6 +277,8 @@ You can use multiple options in conjunction, e.g. "garbo nobarf ascend"',
                 return FarmingMethod.BARF_MOUNTAIN;
 
               case "cowo":
+              case "ranch":
+              case "rancho":
               case "sea cows":
               case "the coral corral":
                 return FarmingMethod.THE_CORAL_CORRAL;

--- a/packages/garbo/src/diet.ts
+++ b/packages/garbo/src/diet.ts
@@ -182,10 +182,9 @@ function eatSafe(qty: number, item: Item) {
   }, item);
 }
 
-const EXPENSIVE_SONGS =
-  farmingStrategy().location.environment === "underwater"
-    ? $effects`The Ballad of Richie Thingfinder, Chorale of Companionship, Donho's Bubbly Ballad`
-    : $effects`The Ballad of Richie Thingfinder, Chorale of Companionship`;
+const EXPENSIVE_SONGS = FarmingStrategy.isUnderwater()
+  ? $effects`The Ballad of Richie Thingfinder, Chorale of Companionship, Donho's Bubbly Ballad`
+  : $effects`The Ballad of Richie Thingfinder, Chorale of Companionship`;
 const USEFUL_SONGS = $effects`Polka of Plenty, Ur-Kel's Aria of Annoyance, Fat Leon's Phat Loot Lyric`;
 function shrugForOde() {
   const inexpensiveSongs = getActiveSongs().filter(

--- a/packages/garbo/src/diet.ts
+++ b/packages/garbo/src/diet.ts
@@ -182,7 +182,10 @@ function eatSafe(qty: number, item: Item) {
   }, item);
 }
 
-const EXPENSIVE_SONGS = $effects`The Ballad of Richie Thingfinder, Chorale of Companionship`;
+const EXPENSIVE_SONGS =
+  farmingStrategy().location.environment === "underwater"
+    ? $effects`The Ballad of Richie Thingfinder, Chorale of Companionship, Donho's Bubbly Ballad`
+    : $effects`The Ballad of Richie Thingfinder, Chorale of Companionship`;
 const USEFUL_SONGS = $effects`Polka of Plenty, Ur-Kel's Aria of Annoyance, Fat Leon's Phat Loot Lyric`;
 function shrugForOde() {
   const inexpensiveSongs = getActiveSongs().filter(
@@ -229,6 +232,9 @@ function drinkSafe(qty: number, item: Item) {
     const odeTurns = qty * item.inebriety;
     const castTurns = odeTurns - haveEffect($effect`Ode to Booze`);
     if (castTurns > 0) {
+      if (getActiveSongs().length >= 4 && !have($effect`Ode to Booze`)) {
+        throw new Error("Unable to make a song slot for Ode to Booze!");
+      }
       useSkill(
         $skill`The Ode to Booze`,
         Math.ceil(castTurns / turnsPerCast($skill`The Ode to Booze`)),

--- a/packages/garbo/src/familiar/constantValueFamiliars.ts
+++ b/packages/garbo/src/familiar/constantValueFamiliars.ts
@@ -23,6 +23,7 @@ import { effectExtenderValue } from "../potions";
 import { globalOptions } from "../config";
 import { canAdventureOrUnlock, unperidotableZones } from "garbo-lib";
 import { estimatedGarboTurns } from "../turns";
+import { FarmingStrategy } from "../farmingStrategy";
 
 type ConstantValueFamiliar = {
   familiar: Familiar;
@@ -190,7 +191,9 @@ function cookbookbatPerilBonus(): number {
   }
 
   const cookbookbatQuestLocations = locationsWithMonsters.filter(
-    (l) => canAdventureOrUnlock(l, false) && !canAdvExclusions.includes(l),
+    (l) =>
+      canAdventureOrUnlock(l, false, FarmingStrategy.isUnderwater()) &&
+      !canAdvExclusions.includes(l),
   );
   const availablePeridotCookbookbatLocations = cookbookbatQuestLocations.filter(
     (l) => PeridotOfPeril.canImperil(l) && !unperidotableZones.includes(l),

--- a/packages/garbo/src/farmingStrategy.ts
+++ b/packages/garbo/src/farmingStrategy.ts
@@ -39,13 +39,15 @@ export function getMonstersToBanish(monstersToBanish: Monster[]): Monster[] {
   return monstersToBanish.filter((monster) => !isBanished(monster));
 }
 
-export function redTaffyWorth(): boolean {
-  const averageRedTaffyValue = sum(
+export function averageRedTaffyValue(): number {
+  return sum(
     [...PulledTaffy.RED_TAFFY_DROP_WEIGHTS.entries()],
     ([item, weight]) => garboValue(item) * weight,
   );
+}
 
-  return mallPrice($item`pulled red taffy`) < averageRedTaffyValue;
+export function redTaffyWorth(): boolean {
+  return mallPrice($item`pulled red taffy`) < averageRedTaffyValue();
 }
 
 const olfactionCopies = have($skill`Transcendent Olfaction`) ? 3 : 0;

--- a/packages/garbo/src/farmingStrategy.ts
+++ b/packages/garbo/src/farmingStrategy.ts
@@ -238,25 +238,22 @@ const THE_CORAL_CORRAL: FarmingStrategyOptions = {
           .item($item`sea lasso`)
           .abortWithMsg("Wild seahorse should have been tamed, what happened?"),
       ),
-    )
-      // Cows are tough! Let's delevel them to be safe
-      .delevel()
-      .tryHaveItem($item`cow poker`);
+    );
 
     if (banish) {
-      const banishMacro = baseMacro.if_(
-        $monsters`Mer-kin rustler, sea cowboy`,
-        banish.macro,
-      );
-
-      return redTaffyWorth()
-        ? banishMacro.tryItem($item`pulled red taffy`).meatKill()
-        : banishMacro.meatKill();
+      baseMacro.if_($monsters`Mer-kin rustler, sea cowboy`, banish.macro);
     }
 
-    return redTaffyWorth()
-      ? baseMacro.tryItem($item`pulled red taffy`).meatKill()
-      : baseMacro.meatKill();
+    // Cows are tough! Let's delevel them to be safe
+    baseMacro.delevel().tryHaveItem($item`cow poker`);
+
+    if (redTaffyWorth()) {
+      baseMacro.tryItem($item`pulled red taffy`);
+    }
+
+    baseMacro.meatKill();
+
+    return baseMacro;
   },
 };
 

--- a/packages/garbo/src/farmingStrategy.ts
+++ b/packages/garbo/src/farmingStrategy.ts
@@ -10,7 +10,6 @@ import {
   Monster,
   print,
 } from "kolmafia";
-import { GarboStrategy } from "./combatStrategy";
 import {
   $effect,
   $effects,
@@ -70,7 +69,7 @@ interface FarmingStrategyOptions {
   ensureML: boolean;
   targetMonster: Delayed<Monster>;
   shouldOlfact: boolean;
-  combat: GarboStrategy<FarmingContext>;
+  macro: (context: FarmingContext) => Macro;
 
   outfit?: (context: FarmingContext) => OutfitSpec;
   ncTurns?: Delayed<number>;
@@ -200,14 +199,7 @@ const BARF_MOUNTAIN: FarmingStrategyOptions = {
         : [],
   }),
 
-  combat: new GarboStrategy(
-    () => Macro.meatKill(),
-    () =>
-      Macro.if_(
-        `(monsterid ${globalOptions.target.id}) && !gotjump && !(pastround 2)`,
-        Macro.meatKill(),
-      ).abort(),
-  ),
+  macro: () => Macro.meatKill(),
 
   post: completeBarfQuest,
 };
@@ -233,7 +225,7 @@ const THE_CORAL_CORRAL: FarmingStrategyOptions = {
     return banishItem ? { equip: [banishItem] } : {};
   },
 
-  combat: new GarboStrategy(({ banish }) => {
+  macro: ({ banish }) => {
     const baseMacro = Macro.externalIf(
       !get("seahorseName"),
       Macro.if_(
@@ -263,7 +255,7 @@ const THE_CORAL_CORRAL: FarmingStrategyOptions = {
     return redTaffyWorth()
       ? baseMacro.tryItem($item`pulled red taffy`).meatKill()
       : baseMacro.meatKill();
-  }),
+  },
 };
 
 function currentStrategy(): FarmingStrategyOptions {

--- a/packages/garbo/src/farmingStrategy.ts
+++ b/packages/garbo/src/farmingStrategy.ts
@@ -145,20 +145,35 @@ const THE_CORAL_CORRAL: FarmingStrategy = {
   },
 
   combat: new GarboStrategy(({ banish }) => {
+    const baseMacro = Macro.externalIf(
+      !get("seahorseName"),
+      Macro.if_(
+        $monster`wild seahorse`,
+        Macro.item($item`sea cowbell`)
+          .item($item`sea cowbell`)
+          .item($item`sea cowbell`)
+          .item($item`sea lasso`)
+          .abortWithMsg("Wild seahorse should have been tamed, what happened?"),
+      ),
+    )
+      // Cows are tough! Let's delevel them to be safe
+      .delevel()
+      .tryHaveItem($item`cow poker`);
+
     if (banish) {
-      const macro = Macro.if_(
+      const banishMacro = baseMacro.if_(
         $monsters`Mer-kin rustler, sea cowboy`,
         banish.macro,
       );
 
       return redTaffyWorth()
-        ? macro.tryItem($item`pulled red taffy`).meatKill()
-        : macro.meatKill();
+        ? banishMacro.tryItem($item`pulled red taffy`).meatKill()
+        : banishMacro.meatKill();
     }
 
     return redTaffyWorth()
-      ? Macro.tryItem($item`pulled red taffy`).meatKill()
-      : Macro.meatKill();
+      ? baseMacro.tryItem($item`pulled red taffy`).meatKill()
+      : baseMacro.meatKill();
   }),
 };
 

--- a/packages/garbo/src/farmingStrategy.ts
+++ b/packages/garbo/src/farmingStrategy.ts
@@ -9,7 +9,6 @@ import {
   Monster,
   print,
 } from "kolmafia";
-import { GarboStrategy } from "./combatStrategy";
 import {
   $effect,
   $effects,
@@ -34,6 +33,7 @@ import { FarmingMethod, globalOptions } from "./config";
 import { completeBarfQuest } from "./resources/realm";
 import { FarmingContext } from "./tasks/context";
 import { garboValue } from "./garboValue";
+import { GarboStrategy } from "./combatStrategy";
 
 export function averageRedTaffyValue(): number {
   return sum(
@@ -67,7 +67,7 @@ interface FarmingStrategyOptions {
   ensureML: boolean;
   targetMonster: Delayed<Monster>;
   shouldOlfact: boolean;
-  combat: GarboStrategy<FarmingContext>;
+  combat: (context: FarmingContext) => Macro;
 
   outfit?: (context: FarmingContext) => OutfitSpec;
   ncTurns?: Delayed<number>;
@@ -151,6 +151,10 @@ class FarmingStrategySkeleton {
   monstersToBanish(): Monster[] {
     return this.banishMonsters.filter((m) => !isBanished(m));
   }
+
+  strategy(): GarboStrategy<FarmingContext> {
+    return new GarboStrategy(this.combat);
+  }
 }
 
 export const FarmingStrategy = new Proxy(
@@ -214,14 +218,7 @@ const BARF_MOUNTAIN: FarmingStrategyOptions = {
         : [],
   }),
 
-  combat: new GarboStrategy(
-    () => Macro.meatKill(),
-    () =>
-      Macro.if_(
-        `(monsterid ${globalOptions.target.id}) && !gotjump && !(pastround 2)`,
-        Macro.meatKill(),
-      ).abort(),
-  ),
+  combat: () => Macro.meatKill(),
 
   post: completeBarfQuest,
 };
@@ -246,22 +243,21 @@ const THE_CORAL_CORRAL: FarmingStrategyOptions = {
     return banishItem ? { equip: [banishItem] } : {};
   },
 
-  combat: new GarboStrategy(({ banish }) => {
-    if (banish) {
-      const macro = Macro.if_(
-        $monsters`Mer-kin rustler, sea cowboy`,
-        banish.macro,
-      );
-
-      return redTaffyWorth()
-        ? macro.tryItem($item`pulled red taffy`).meatKill()
-        : macro.meatKill();
-    }
-
-    return redTaffyWorth()
-      ? Macro.tryItem($item`pulled red taffy`).meatKill()
-      : Macro.meatKill();
-  }),
+  combat: ({ banish }) =>
+    Macro.externalIf(
+      !get("seahorseName"),
+      Macro.if_(
+        $monster`wild seahorse`,
+        Macro.item($item`sea cowbell`)
+          .item($item`sea cowbell`)
+          .item($item`sea cowbell`)
+          .item($item`sea lasso`)
+          .abortWithMsg("Wild seahorse should have been tamed, what happened?"),
+      ),
+    )
+      .farmingBanish(banish)
+      .externalIf(redTaffyWorth(), Macro.tryItem($item`pulled red taffy`))
+      .meatKill(),
 };
 
 function currentStrategy(): FarmingStrategyOptions {

--- a/packages/garbo/src/farmingStrategy.ts
+++ b/packages/garbo/src/farmingStrategy.ts
@@ -103,7 +103,7 @@ class FarmingStrategySkeleton {
     return this.location.environment === "underwater";
   }
   accountForNC(): boolean {
-    return this.ncTurns === Infinity;
+    return this.ncTurns !== Infinity;
   }
 
   olfactMonster(): Monster | null {

--- a/packages/garbo/src/farmingStrategy.ts
+++ b/packages/garbo/src/farmingStrategy.ts
@@ -40,8 +40,6 @@ export function getMonstersToBanish(monstersToBanish: Monster[]): Monster[] {
 
 export function averageRedTaffyValue(): number {
   return sum(
-export function redTaffyWorth(): boolean {
-  const averageRedTaffyValue = sum(
     [...PulledTaffy.RED_TAFFY_DROP_WEIGHTS.entries()],
     ([item, weight]) => garboValue(item) * weight,
   );

--- a/packages/garbo/src/farmingStrategy.ts
+++ b/packages/garbo/src/farmingStrategy.ts
@@ -43,7 +43,6 @@ export function averageRedTaffyValue(): number {
 }
 
 export function redTaffyWorth(): boolean {
-
   return mallPrice($item`pulled red taffy`) < averageRedTaffyValue();
 }
 

--- a/packages/garbo/src/farmingStrategy.ts
+++ b/packages/garbo/src/farmingStrategy.ts
@@ -9,6 +9,7 @@ import {
   Monster,
   print,
 } from "kolmafia";
+import { GarboStrategy } from "./combatStrategy";
 import {
   $effect,
   $effects,
@@ -34,10 +35,6 @@ import { completeBarfQuest } from "./resources/realm";
 import { FarmingContext } from "./tasks/context";
 import { garboValue } from "./garboValue";
 
-export function getMonstersToBanish(monstersToBanish: Monster[]): Monster[] {
-  return monstersToBanish.filter((monster) => !isBanished(monster));
-}
-
 export function averageRedTaffyValue(): number {
   return sum(
     [...PulledTaffy.RED_TAFFY_DROP_WEIGHTS.entries()],
@@ -46,6 +43,7 @@ export function averageRedTaffyValue(): number {
 }
 
 export function redTaffyWorth(): boolean {
+
   return mallPrice($item`pulled red taffy`) < averageRedTaffyValue();
 }
 
@@ -70,7 +68,7 @@ interface FarmingStrategyOptions {
   ensureML: boolean;
   targetMonster: Delayed<Monster>;
   shouldOlfact: boolean;
-  macro: (context: FarmingContext) => Macro;
+  combat: GarboStrategy<FarmingContext>;
 
   outfit?: (context: FarmingContext) => OutfitSpec;
   ncTurns?: Delayed<number>;
@@ -217,7 +215,14 @@ const BARF_MOUNTAIN: FarmingStrategyOptions = {
         : [],
   }),
 
-  macro: () => Macro.meatKill(),
+  combat: new GarboStrategy(
+    () => Macro.meatKill(),
+    () =>
+      Macro.if_(
+        `(monsterid ${globalOptions.target.id}) && !gotjump && !(pastround 2)`,
+        Macro.meatKill(),
+      ).abort(),
+  ),
 
   post: completeBarfQuest,
 };
@@ -242,34 +247,22 @@ const THE_CORAL_CORRAL: FarmingStrategyOptions = {
     return banishItem ? { equip: [banishItem] } : {};
   },
 
-  macro: ({ banish }) => {
-    const baseMacro = Macro.externalIf(
-      !get("seahorseName"),
-      Macro.if_(
-        $monster`wild seahorse`,
-        Macro.item($item`sea cowbell`)
-          .item($item`sea cowbell`)
-          .item($item`sea cowbell`)
-          .item($item`sea lasso`)
-          .abortWithMsg("Wild seahorse should have been tamed, what happened?"),
-      ),
-    );
-
+  combat: new GarboStrategy(({ banish }) => {
     if (banish) {
-      baseMacro.if_($monsters`Mer-kin rustler, sea cowboy`, banish.macro);
+      const macro = Macro.if_(
+        $monsters`Mer-kin rustler, sea cowboy`,
+        banish.macro,
+      );
+
+      return redTaffyWorth()
+        ? macro.tryItem($item`pulled red taffy`).meatKill()
+        : macro.meatKill();
     }
 
-    // Cows are tough! Let's delevel them to be safe
-    baseMacro.delevel().tryHaveItem($item`cow poker`);
-
-    if (redTaffyWorth()) {
-      baseMacro.tryItem($item`pulled red taffy`);
-    }
-
-    baseMacro.meatKill();
-
-    return baseMacro;
-  },
+    return redTaffyWorth()
+      ? Macro.tryItem($item`pulled red taffy`).meatKill()
+      : Macro.meatKill();
+  }),
 };
 
 function currentStrategy(): FarmingStrategyOptions {

--- a/packages/garbo/src/garboWanderer.ts
+++ b/packages/garbo/src/garboWanderer.ts
@@ -41,6 +41,7 @@ export function wanderer(): WandererManager {
       valueOfAdventure: get("valueOfAdventure"),
       takeTurnForProfit: true,
       canRefractedGaze: BloodCubicZirconia.have() && safeRefractedCasts() > 0,
+      underwaterAllowed: FarmingStrategy.isUnderwater(),
     });
   }
   return _wanderer;

--- a/packages/garbo/src/lib.ts
+++ b/packages/garbo/src/lib.ts
@@ -488,12 +488,11 @@ export function safeRestore(): void {
     }
   }
   // Cows are tough, especially when overdrunk
-  const lowPercentageHealth =
-    farmingStrategy().location.environment === "underwater"
-      ? myInebriety() > inebrietyLimit()
-        ? 0.9
-        : 0.6
-      : 0.5;
+  const lowPercentageHealth = FarmingStrategy.isUnderwater()
+    ? myInebriety() > inebrietyLimit()
+      ? 0.9
+      : 0.6
+    : 0.5;
 
   if (
     myHp() <

--- a/packages/garbo/src/lib.ts
+++ b/packages/garbo/src/lib.ts
@@ -500,7 +500,21 @@ export function safeRestore(): void {
       );
     }
   }
-  if (myHp() < Math.min(myMaxhp() * 0.5, get("garbo_restoreHpTarget", 2000))) {
+  // Cows are tough, especially when overdrunk
+  const lowPercentageHealth =
+    farmingStrategy().location.environment === "underwater"
+      ? myInebriety() > inebrietyLimit()
+        ? 0.9
+        : 0.6
+      : 0.5;
+
+  if (
+    myHp() <
+    Math.min(
+      myMaxhp() * lowPercentageHealth,
+      get("garbo_restoreHpTarget", 2000),
+    )
+  ) {
     restoreHp(Math.min(myMaxhp() * 0.9, get("garbo_restoreHpTarget", 2000)));
   }
   const mpTarget = safeRestoreMpTarget();

--- a/packages/garbo/src/mood.ts
+++ b/packages/garbo/src/mood.ts
@@ -5,9 +5,11 @@ import {
   Effect,
   getWorkshed,
   haveEffect,
+  inebrietyLimit,
   itemAmount,
   mallPrice,
   myClass,
+  myInebriety,
   myLevel,
   numericModifier,
   use,
@@ -34,6 +36,8 @@ import { usingPurse } from "./outfit";
 import { effectValue } from "./potions";
 import { acquire } from "./acquire";
 import { farmingStrategy } from "./farmingStrategy";
+import { estimatedGarboTurns } from "./turns";
+import { globalOptions } from "./config";
 
 Mood.setDefaultOptions({
   songSlots: [
@@ -69,7 +73,7 @@ export function meatMood(
     mood.effect($effect`Thoughtful Empathy`);
     mood.effect($effect`Lubricating Sauce`);
     mood.effect($effect`Tubes of Universal Meat`);
-    mood.effect($effect`Strength of the Tortoise`);
+    mood.effect($effect`Strength of the Tortoise`); // Can we disable this one somehow for when we do Piraterealm?
   }
 
   mood.skill($skill`The Polka of Plenty`);
@@ -87,12 +91,44 @@ export function meatMood(
         ? $skill`Ur-Kel's Aria of Annoyance`
         : $skill`Fat Leon's Phat Loot Lyric`,
     );
-  } else {
-    // This could be optimized a bit better using the new setup
-    mood.skill($skill`Donho's Bubbly Ballad`);
+  }
+
+  if (farmingStrategy().location === $location`The Coral Corral`) {
+    // Cow survivability
+    mood.skill($skill`Ruthless Efficiency`);
     mood.skill($skill`Ghostly Shell`);
     mood.skill($skill`Shield of the Pastalord`);
+    // Better pearl progress
+    mood.skill($skill`Astral Shell`);
+    mood.skill($skill`Elemental Saucesphere`);
+    // Donho's
+    const availableDonhoTurnsFromSkill = 10 * (50 - get("_donhosCasts"));
+    if (get("_donhosCasts") < 50 && !globalOptions.ascend) {
+      useSkill($skill`Donho's Bubbly Ballad`, 50 - get("_donhosCasts"));
+    } else if (
+      get("_donhosCasts") < 50 &&
+      availableDonhoTurnsFromSkill > estimatedGarboTurns()
+    ) {
+      mood.skill($skill`Donho's Bubbly Ballad`);
+    } else {
+      useSkill($skill`Donho's Bubbly Ballad`, 50 - get("_donhosCasts"));
+      mood.potion($item`recording of Donho's Bubbly Ballad`, 0.2 * meat);
+    }
+
+    // Overdrunk survivability
+    if (myInebriety() > inebrietyLimit()) {
+      mood.skill($skill`Get Big`);
+      mood.skill($skill`Song of Bravado`);
+      mood.skill($skill`Rage of the Reindeer`);
+      mood.skill($skill`Disco Fever`);
+      mood.skill($skill`Carol of the Bulls`);
+      mood.skill($skill`Blood Bubble`);
+      mood.skill($skill`Tenacity of the Snapper`);
+      mood.skill($skill`Grease Up`);
+      mood.effect($effect`Disco over Matter`);
+    }
   }
+
   mood.skill($skill`Walk: Leisurely Amble`);
   mood.skill($skill`Call For Backup`);
   mood.skill($skill`Soothing Flute`);

--- a/packages/garbo/src/outfit/dropsgearAccessories.ts
+++ b/packages/garbo/src/outfit/dropsgearAccessories.ts
@@ -11,6 +11,7 @@ import {
   $class,
   $item,
   $items,
+  $location,
   $skill,
   $slot,
   CinchoDeMayo,
@@ -139,8 +140,9 @@ function cinchoDeMayo(mode: BonusEquipMode) {
     !monsterManuelAvailable() ||
     // If we're doing Yachtzees, only use up excess cincho.
     maximumPinataCasts() <= 0 ||
-    // If we have more than 50 passive damage, we'll never be able to cast projectile pinata without risking the monster dying
-    maxPassiveDamage() >= 50
+    // If we have more than 50 passive damage, we'll never be able to cast projectile pinata without risking the monster dying. Cows are tankier though.
+    maxPassiveDamage() >=
+      (farmingStrategy().location === $location`The Coral Corral` ? 150 : 50)
   ) {
     return new Map<Item, number>([]);
   }

--- a/packages/garbo/src/outfit/dropsgearAccessories.ts
+++ b/packages/garbo/src/outfit/dropsgearAccessories.ts
@@ -11,7 +11,6 @@ import {
   $class,
   $item,
   $items,
-  $location,
   $skill,
   $slot,
   CinchoDeMayo,
@@ -141,8 +140,7 @@ function cinchoDeMayo(mode: BonusEquipMode) {
     // If we're doing Yachtzees, only use up excess cincho.
     maximumPinataCasts() <= 0 ||
     // If we have more than 50 passive damage, we'll never be able to cast projectile pinata without risking the monster dying. Cows are tankier though.
-    maxPassiveDamage() >=
-      (farmingStrategy().location === $location`The Coral Corral` ? 150 : 50)
+    maxPassiveDamage() >= (FarmingStrategy.isUnderwater() ? 150 : 50)
   ) {
     return new Map<Item, number>([]);
   }

--- a/packages/garbo/src/potions.ts
+++ b/packages/garbo/src/potions.ts
@@ -192,9 +192,7 @@ export const VALUABLE_MODIFIERS = [
   "Familiar Weight",
   "Smithsness",
   "Item Drop",
-  farmingStrategy().location === $location`The Coral Corral`
-    ? "Hidden Familiar Weight"
-    : "",
+  "Hidden Familiar Weight", // How can I add this only if farming strategy is underwater? It's a const
 ] as const;
 
 const BUFFER_TURNS = 30;

--- a/packages/garbo/src/potions.ts
+++ b/packages/garbo/src/potions.ts
@@ -192,6 +192,9 @@ export const VALUABLE_MODIFIERS = [
   "Familiar Weight",
   "Smithsness",
   "Item Drop",
+  farmingStrategy().location === $location`The Coral Corral`
+    ? "Hidden Familiar Weight"
+    : "",
 ] as const;
 
 const BUFFER_TURNS = 30;

--- a/packages/garbo/src/potions.ts
+++ b/packages/garbo/src/potions.ts
@@ -987,7 +987,7 @@ class VariableMeatPotion {
     const targetValue = targetMeat();
     const barfValue = FarmingStrategy.accountForNC()
       ? (baseMeat() * FarmingStrategy.turnsToNC()) / 30
-      : 0;
+      : baseMeat();
 
     const totalCosts = retrievePrice(this.potion, n);
     const totalDuration = n * this.duration;

--- a/packages/garbo/src/resources/aprilingband.ts
+++ b/packages/garbo/src/resources/aprilingband.ts
@@ -1,6 +1,5 @@
 import {
   $item,
-  $location,
   AprilingBandHelmet,
   clamp,
   get,
@@ -13,7 +12,7 @@ import { getBestLuckyAdventure } from "../lib";
 import getExperienceFamiliars from "../familiar/experienceFamiliars";
 import { toItem } from "kolmafia";
 import { estimatedBarfExperience } from "../familiar";
-import { farmingStrategy } from "../farmingStrategy";
+import { FarmingStrategy } from "../farmingStrategy";
 
 const instruments: {
   instrument: AprilingBandHelmet.Instrument;
@@ -38,8 +37,7 @@ const instruments: {
   {
     instrument: "Apriling band tuba",
     value: () =>
-      realmAvailable("sleaze") &&
-      farmingStrategy().location === $location`The Coral Corral`
+      realmAvailable("sleaze") && FarmingStrategy.isUnderwater()
         ? (20000 - get("valueOfAdventure")) * 3 // Yachtzee
         : 0, // Are there any other valuable NCs?
   },

--- a/packages/garbo/src/resources/aprilingband.ts
+++ b/packages/garbo/src/resources/aprilingband.ts
@@ -1,5 +1,6 @@
 import {
   $item,
+  $location,
   AprilingBandHelmet,
   clamp,
   get,
@@ -12,6 +13,7 @@ import { getBestLuckyAdventure } from "../lib";
 import getExperienceFamiliars from "../familiar/experienceFamiliars";
 import { toItem } from "kolmafia";
 import { estimatedBarfExperience } from "../familiar";
+import { farmingStrategy } from "../farmingStrategy";
 
 const instruments: {
   instrument: AprilingBandHelmet.Instrument;
@@ -32,6 +34,14 @@ const instruments: {
   {
     instrument: "Apriling band saxophone",
     value: () => getBestLuckyAdventure().value() * 3,
+  },
+  {
+    instrument: "Apriling band tuba",
+    value: () =>
+      realmAvailable("sleaze") &&
+      farmingStrategy().location === $location`The Coral Corral`
+        ? (20000 - get("valueOfAdventure")) * 3 // Yachtzee
+        : 0, // Are there any other valuable NCs?
   },
   {
     instrument: "Apriling band piccolo",

--- a/packages/garbo/src/resources/extrovermectin.ts
+++ b/packages/garbo/src/resources/extrovermectin.ts
@@ -55,6 +55,7 @@ import { garboAdventure, Macro } from "../combat";
 import { acquire } from "../acquire";
 import { globalOptions } from "../config";
 import { AdventureArgument } from "../garboWanderer";
+import { waveDireWarren } from "./seaDent";
 
 const crate = $monster`crate`;
 
@@ -532,6 +533,7 @@ function banishBunny(): void {
     "fluffy bunny" !== get("lastEncounter") &&
     !get("banishedMonsters").includes("fluffy bunny")
   );
+  waveDireWarren();
 }
 
 function getBanishedPhyla(): Map<Skill | Item, Phylum> {

--- a/packages/garbo/src/resources/index.ts
+++ b/packages/garbo/src/resources/index.ts
@@ -22,3 +22,4 @@ export * from "./archaelogistSpade";
 export * from "./lucky";
 export * from "./doghouse";
 export * from "./clanVIP";
+export * from "./seaDent";

--- a/packages/garbo/src/resources/seaDent.ts
+++ b/packages/garbo/src/resources/seaDent.ts
@@ -1,0 +1,30 @@
+import { abort, haveEffect, useSkill } from "kolmafia";
+import {
+  $effect,
+  $item,
+  $location,
+  $skill,
+  get,
+  have,
+  withChoice,
+} from "libram";
+import { copyTargetCount } from "../target";
+import { farmingStrategy } from "../farmingStrategy";
+
+export function waveDireWarren() {
+  if (
+    farmingStrategy().location === $location`The Coral Corral` &&
+    have($item`Monodent of the Sea`) &&
+    haveEffect($effect`Fishy`) > copyTargetCount() + 50 && // Let's be very careful
+    !get("_seadentWaveUsed") &&
+    get("_seadentWaveZone") !== "The Dire Warren" &&
+    get("lastAdventure") === $location`The Dire Warren`
+  ) {
+    withChoice(1566, 1, () => {
+      useSkill($skill`Sea *dent: Summon a Wave`);
+    });
+    if (get("_seadentWaveZone") !== "The Dire Warren") {
+      abort("Something went wrong while waving Dire Warren");
+    }
+  }
+}

--- a/packages/garbo/src/resources/seaDent.ts
+++ b/packages/garbo/src/resources/seaDent.ts
@@ -9,11 +9,11 @@ import {
   withChoice,
 } from "libram";
 import { copyTargetCount } from "../target";
-import { farmingStrategy } from "../farmingStrategy";
+import { FarmingStrategy } from "../farmingStrategy";
 
 export function waveDireWarren() {
   if (
-    farmingStrategy().location === $location`The Coral Corral` &&
+    FarmingStrategy.isUnderwater() &&
     have($item`Monodent of the Sea`) &&
     haveEffect($effect`Fishy`) > copyTargetCount() + 50 && // Let's be very careful
     !get("_seadentWaveUsed") &&

--- a/packages/garbo/src/resources/yachtzee.ts
+++ b/packages/garbo/src/resources/yachtzee.ts
@@ -1,6 +1,7 @@
 import {
   $effect,
   $item,
+  $location,
   CinchoDeMayo,
   clamp,
   get,
@@ -9,6 +10,7 @@ import {
 } from "libram";
 import { felizValue } from "../lib";
 import { haveEffect, myAdventures } from "kolmafia";
+import { farmingStrategy } from "../farmingStrategy";
 
 const CLARA_TARGETS = [
   "volcoino",
@@ -19,6 +21,7 @@ const CLARA_TARGETS = [
 type ClaraTarget = (typeof CLARA_TARGETS)[number];
 
 export const fishyTurns = () =>
+  (farmingStrategy().location === $location`The Coral Corral` ? 100 : 0) + // If we're farming cows, we should always have some fishy available when we want to yachtzee end of day
   Math.max(haveEffect($effect`Fishy`) - myAdventures(), 0) +
   (have($item`fishy pipe`) && !get("_fishyPipeUsed") ? 10 : 0) +
   (get("skateParkStatus") === "ice" && !get("_skateBuff1") ? 30 : 0);
@@ -54,6 +57,14 @@ export const nonCinchNCs = () =>
         ? $item`Apriling band tuba`.dailyusesleft
         : 0);
 
+export const combatNCs = () =>
+  have($item`McHugeLarge left ski`)
+    ? Math.max(0, 3 - get("_mcHugeLargeAvalancheUses"))
+    : 0 +
+      (have($item`Jurassic Parka`)
+        ? Math.max(0, 5 - get("_spikolodonSpikeUses"))
+        : 0);
+
 export const cinchNCs = () =>
   Math.min(
     Math.floor(CinchoDeMayo.totalAvailableCinch() / 60),
@@ -61,7 +72,7 @@ export const cinchNCs = () =>
   );
 
 export const maximumYachtzees = () =>
-  clamp(nonCinchNCs() + cinchNCs(), 0, fishyTurns());
+  clamp(nonCinchNCs() + cinchNCs() + combatNCs(), 0, fishyTurns());
 
 export const willYachtzee = () => canYachtzee() && maximumYachtzees() > 0;
 

--- a/packages/garbo/src/resources/yachtzee.ts
+++ b/packages/garbo/src/resources/yachtzee.ts
@@ -1,7 +1,6 @@
 import {
   $effect,
   $item,
-  $location,
   CinchoDeMayo,
   clamp,
   get,
@@ -10,7 +9,7 @@ import {
 } from "libram";
 import { felizValue } from "../lib";
 import { haveEffect, myAdventures } from "kolmafia";
-import { farmingStrategy } from "../farmingStrategy";
+import { FarmingStrategy } from "../farmingStrategy";
 
 const CLARA_TARGETS = [
   "volcoino",
@@ -21,7 +20,7 @@ const CLARA_TARGETS = [
 type ClaraTarget = (typeof CLARA_TARGETS)[number];
 
 export const fishyTurns = () =>
-  (farmingStrategy().location === $location`The Coral Corral` ? 100 : 0) + // If we're farming cows, we should always have some fishy available when we want to yachtzee end of day
+  (FarmingStrategy.isUnderwater() ? 100 : 0) + // If we're farming cows, we should always have some fishy available when we want to yachtzee end of day
   Math.max(haveEffect($effect`Fishy`) - myAdventures(), 0) +
   (have($item`fishy pipe`) && !get("_fishyPipeUsed") ? 10 : 0) +
   (get("skateParkStatus") === "ice" && !get("_skateBuff1") ? 30 : 0);

--- a/packages/garbo/src/resources/yachtzee.ts
+++ b/packages/garbo/src/resources/yachtzee.ts
@@ -57,12 +57,12 @@ export const nonCinchNCs = () =>
         : 0);
 
 export const combatNCs = () =>
-  have($item`McHugeLarge left ski`)
+  (have($item`McHugeLarge left ski`)
     ? Math.max(0, 3 - get("_mcHugeLargeAvalancheUses"))
-    : 0 +
-      (have($item`Jurassic Parka`)
-        ? Math.max(0, 5 - get("_spikolodonSpikeUses"))
-        : 0);
+    : 0) +
+  (have($item`Jurassic Parka`)
+    ? Math.max(0, 5 - get("_spikolodonSpikeUses"))
+    : 0);
 
 export const cinchNCs = () =>
   Math.min(

--- a/packages/garbo/src/target/fights.ts
+++ b/packages/garbo/src/target/fights.ts
@@ -70,6 +70,7 @@ import {
   monsterIsInEggnet,
   possibleGregCrystalBall,
   totalGregCharges,
+  waveDireWarren,
 } from "../resources";
 import { nextWeekFights } from "../resources/sealclub";
 import { acquire } from "../acquire";
@@ -559,6 +560,7 @@ const gregFights = (
         `Fluffy bunny is supposedly banished by ${bunnyBanish}, but this appears not to be the case; the most likely issue is that your ${fightsProp} preference is nonzero and should probably be zero.`,
       );
     }
+    waveDireWarren();
   }
 
   const resourceIsOccupied = () =>

--- a/packages/garbo/src/target/lib.ts
+++ b/packages/garbo/src/target/lib.ts
@@ -27,7 +27,7 @@ import { Macro } from "../combat";
 import { globalOptions } from "../config";
 import { freeFishyAvailable } from "../lib";
 import { willYachtzee } from "../resources";
-import { farmingStrategy } from "../farmingStrategy";
+import { FarmingStrategy } from "../farmingStrategy";
 
 /**
  * Configure the behavior of the fights in use in different parts of the fight engine
@@ -63,8 +63,7 @@ export function checkUnderwater(): boolean {
     (booleanModifier("Adventure Underwater") ||
       waterBreathingEquipment.some((item) => have(item) && canEquip(item))) &&
     freeFishyAvailable() &&
-    (!willYachtzee() ||
-      farmingStrategy().location === $location`The Coral Corral`)
+    (!willYachtzee() || FarmingStrategy.isUnderwater())
   ) {
     if (
       !have($effect`Fishy`) &&

--- a/packages/garbo/src/target/lib.ts
+++ b/packages/garbo/src/target/lib.ts
@@ -27,6 +27,7 @@ import { Macro } from "../combat";
 import { globalOptions } from "../config";
 import { freeFishyAvailable } from "../lib";
 import { willYachtzee } from "../resources";
+import { farmingStrategy } from "../farmingStrategy";
 
 /**
  * Configure the behavior of the fights in use in different parts of the fight engine
@@ -62,7 +63,8 @@ export function checkUnderwater(): boolean {
     (booleanModifier("Adventure Underwater") ||
       waterBreathingEquipment.some((item) => have(item) && canEquip(item))) &&
     freeFishyAvailable() &&
-    !willYachtzee()
+    (!willYachtzee() ||
+      farmingStrategy().location === $location`The Coral Corral`)
   ) {
     if (
       !have($effect`Fishy`) &&

--- a/packages/garbo/src/tasks/dailyFamiliars.ts
+++ b/packages/garbo/src/tasks/dailyFamiliars.ts
@@ -47,7 +47,7 @@ import { GarboContext } from "./context";
 function drivebyValue(targetCount = 0): number {
   const targets = targetCount;
 
-  const tourists = farmingStrategy().accountForNC
+  const baseFarmFights = farmingStrategy().accountForNC
     ? ((estimatedGarboTurns() - targets) * farmingStrategy().turnsToNC()) /
       (farmingStrategy().turnsToNC() + 1)
     : 0;
@@ -60,14 +60,15 @@ function drivebyValue(targetCount = 0): number {
     2 * marginalRoboWeight;
 
   return (
-    (meatPercentDelta / 100) * (targetMeat() * targets + baseMeat() * tourists)
+    (meatPercentDelta / 100) *
+    (targetMeat() * targets + baseMeat() * baseFarmFights)
   );
 }
 
 function entendreValue(targetCount = 0): number {
   const targets = targetCount;
 
-  const tourists = farmingStrategy().accountForNC
+  const baseFarmFights = farmingStrategy().accountForNC
     ? ((estimatedGarboTurns() - targets) * farmingStrategy().turnsToNC()) /
       (farmingStrategy().turnsToNC() + 1)
     : 0;
@@ -80,7 +81,8 @@ function entendreValue(targetCount = 0): number {
   const garbageBagsDropRate = 0.15 * 3; // 3 bags each with a 15% drop chance
 
   return (
-    (itemPercent / 100) * (garbageBagsDropRate * tourists * garbageTouristRatio)
+    (itemPercent / 100) *
+    (garbageBagsDropRate * baseFarmFights * garbageTouristRatio)
   );
 }
 

--- a/packages/garbo/src/tasks/farm/farmTurn.ts
+++ b/packages/garbo/src/tasks/farm/farmTurn.ts
@@ -1,5 +1,12 @@
 import { $item, $location, $monster, get, have, undelay } from "libram";
-import { Item, mallPrice, myAdventures, myLocation, toMonster } from "kolmafia";
+import {
+  Item,
+  mallPrice,
+  myAdventures,
+  myLocation,
+  toMonster,
+  totalTurnsPlayed,
+} from "kolmafia";
 import { $effect, CrepeParachute } from "libram";
 import { Quest } from "grimoire-kolmafia";
 
@@ -40,7 +47,16 @@ export const farmPrepare = (context: FarmingContext) => {
     acquire(3, $item`sea cowbell`, 5000, true); // Arbitrary max price
     acquire(1, $item`sea lasso`, 5000, true);
   }
-  meatMood().execute(estimatedGarboTurns());
+
+  if (
+    FarmingStrategy.location === $location`Barf Mountain` &&
+    !get("dinseyRollercoasterNext") &&
+    !(totalTurnsPlayed() % 11)
+  ) {
+    meatMood().execute(estimatedGarboTurns());
+  } else {
+    meatMood().execute(estimatedGarboTurns());
+  }
 
   if (context.banish?.retrieve && context.banish.source instanceof Item) {
     acquire(1, context.banish.source, mallPrice(context.banish.source) * 1.2); // Sanity check on price, 20%

--- a/packages/garbo/src/tasks/farm/farmTurn.ts
+++ b/packages/garbo/src/tasks/farm/farmTurn.ts
@@ -48,14 +48,15 @@ export const farmPrepare = (context: FarmingContext) => {
     acquire(1, $item`sea lasso`, 5000, true);
   }
 
-  if (
-    FarmingStrategy.location === $location`Barf Mountain` &&
-    !get("dinseyRollercoasterNext") &&
-    !(totalTurnsPlayed() % 11)
-  ) {
-    meatMood().execute(estimatedGarboTurns());
-  } else {
-    meatMood().execute(estimatedGarboTurns());
+  // Only re-run mood every so often
+  if (!(totalTurnsPlayed() % 11)) {
+    if (
+      (FarmingStrategy.location === $location`Barf Mountain` &&
+        !get("dinseyRollercoasterNext")) ||
+      FarmingStrategy.location !== $location`Barf Mountain`
+    ) {
+      meatMood().execute(estimatedGarboTurns());
+    }
   }
 
   if (context.banish?.retrieve && context.banish.source instanceof Item) {

--- a/packages/garbo/src/tasks/farm/farmTurn.ts
+++ b/packages/garbo/src/tasks/farm/farmTurn.ts
@@ -27,6 +27,38 @@ import { barfOutfit } from "../../outfit";
 import { FarmingContext } from "../context";
 import { GarboStrategy } from "../../combatStrategy";
 
+export const farmPrepare = (context: FarmingContext) => {
+  if (redTaffyWorth() && FarmingStrategy.isUnderwater()) {
+    retrieveItem($item`pulled red taffy`);
+  }
+  meatMood().execute(estimatedGarboTurns());
+
+  if (context.banish?.retrieve && context.banish.source instanceof Item) {
+    retrieveItem(context.banish.source);
+  }
+};
+
+export const farmPost = () => {
+  FarmingStrategy.post?.();
+  trackMarginalMpa();
+
+  if (toMonster(get("lastEncounter")) === $monster`tumbleweed`) {
+    throw new Error(
+      "You encountered a tumbleweed and should not have, resolve your banishes",
+    );
+  }
+
+  if (
+    getMonstersToBanish(FarmingStrategy.banishMonsters).includes(
+      toMonster(get("lastEncounter")),
+    )
+  ) {
+    throw new Error(
+      "You encountered a banishable monster and didn't banish it, sort your life out!",
+    );
+  }
+};
+
 export function FarmTurnQuest(): Quest<
   GarboTask<FarmingContext>,
   FarmingContext
@@ -56,42 +88,11 @@ export function FarmTurnQuest(): Quest<
       {
         name: "Farm",
         completed: () => myAdventures() === 0,
-        prepare: (context) => {
-          if (redTaffyWorth() && FarmingStrategy.isUnderwater()) {
-            retrieveItem($item`pulled red taffy`);
-          }
-          meatMood().execute(estimatedGarboTurns());
-
-          if (
-            context.banish?.retrieve &&
-            context.banish.source instanceof Item
-          ) {
-            retrieveItem(context.banish.source);
-          }
-        },
+        prepare: farmPrepare,
         outfit: (context) => barfOutfit(FarmingStrategy.outfit(context)),
         do: () => FarmingStrategy.location,
         combat: new GarboStrategy((context) => FarmingStrategy.macro(context)),
-        post: () => {
-          FarmingStrategy.post?.();
-          trackMarginalMpa();
-
-          if (toMonster(get("lastEncounter")) === $monster`tumbleweed`) {
-            throw new Error(
-              "You encountered a tumbleweed and should not have, resolve your banishes",
-            );
-          }
-
-          if (
-            getMonstersToBanish(FarmingStrategy.banishMonsters).includes(
-              toMonster(get("lastEncounter")),
-            )
-          ) {
-            throw new Error(
-              "You encountered a banishable monster and didn't banish it, sort your life out!",
-            );
-          }
-        },
+        post: farmPost,
         spendsTurn: true,
       },
     ],

--- a/packages/garbo/src/tasks/farm/farmTurn.ts
+++ b/packages/garbo/src/tasks/farm/farmTurn.ts
@@ -25,6 +25,7 @@ import { meatMood } from "../../mood";
 import { estimatedGarboTurns } from "../../turns";
 import { barfOutfit } from "../../outfit";
 import { FarmingContext } from "../context";
+import { GarboStrategy } from "../../combatStrategy";
 
 export function FarmTurnQuest(): Quest<
   GarboTask<FarmingContext>,
@@ -44,7 +45,7 @@ export function FarmTurnQuest(): Quest<
           have($effect`Everything looks Beige`) || myAdventures() === 0,
         outfit: (context) => barfOutfit(FarmingStrategy.outfit(context)),
         do: () => CrepeParachute.fight(undelay(FarmingStrategy.targetMonster)),
-        combat: FarmingStrategy.combat,
+        combat: new GarboStrategy((context) => FarmingStrategy.macro(context)),
         post: () => {
           FarmingStrategy.post?.();
           if (!have($effect`Everything looks Beige`)) updateParachuteFailure();
@@ -70,7 +71,7 @@ export function FarmTurnQuest(): Quest<
         },
         outfit: (context) => barfOutfit(FarmingStrategy.outfit(context)),
         do: () => FarmingStrategy.location,
-        combat: FarmingStrategy.combat,
+        combat: new GarboStrategy((context) => FarmingStrategy.macro(context)),
         post: () => {
           FarmingStrategy.post?.();
           trackMarginalMpa();

--- a/packages/garbo/src/tasks/farm/farmTurn.ts
+++ b/packages/garbo/src/tasks/farm/farmTurn.ts
@@ -1,11 +1,5 @@
-import { $item, $monster, get, have, undelay } from "libram";
-import {
-  Item,
-  myAdventures,
-  myLocation,
-  retrieveItem,
-  toMonster,
-} from "kolmafia";
+import { $item, $location, $monster, get, have, undelay } from "libram";
+import { Item, mallPrice, myAdventures, myLocation, toMonster } from "kolmafia";
 import { $effect, CrepeParachute } from "libram";
 import { Quest } from "grimoire-kolmafia";
 
@@ -16,6 +10,7 @@ import {
   updateParachuteFailure,
 } from "./lib";
 import {
+  averageRedTaffyValue,
   FarmingStrategy,
   getMonstersToBanish,
   redTaffyWorth,
@@ -26,15 +21,29 @@ import { estimatedGarboTurns } from "../../turns";
 import { barfOutfit } from "../../outfit";
 import { FarmingContext } from "../context";
 import { GarboStrategy } from "../../combatStrategy";
+import { acquire } from "../../acquire";
 
 export const farmPrepare = (context: FarmingContext) => {
   if (redTaffyWorth() && FarmingStrategy.isUnderwater()) {
-    retrieveItem($item`pulled red taffy`);
+    acquire(
+      estimatedGarboTurns(),
+      $item`pulled red taffy`,
+      averageRedTaffyValue(),
+      false, // It's fine to continue running if there aren't appropriately priced taffies
+    );
+  }
+  if (
+    FarmingStrategy.location === $location`The Coral Corral` &&
+    get("seahorseName") === "" &&
+    get("lassoTrainingCount") >= 20
+  ) {
+    acquire(3, $item`sea cowbell`, 5000, true); // Arbitrary max price
+    acquire(1, $item`sea lasso`, 5000, true);
   }
   meatMood().execute(estimatedGarboTurns());
 
   if (context.banish?.retrieve && context.banish.source instanceof Item) {
-    retrieveItem(context.banish.source);
+    acquire(1, context.banish.source, mallPrice(context.banish.source) * 1.2); // Sanity check on price, 20%
   }
 };
 

--- a/packages/garbo/src/tasks/farm/farmTurn.ts
+++ b/packages/garbo/src/tasks/farm/farmTurn.ts
@@ -80,7 +80,7 @@ export function FarmTurnQuest(): Quest<
           have($effect`Everything looks Beige`) || myAdventures() === 0,
         outfit: (context) => barfOutfit(FarmingStrategy.outfit(context)),
         do: () => CrepeParachute.fight(undelay(FarmingStrategy.targetMonster)),
-        combat: FarmingStrategy.combat,
+        combat: FarmingStrategy.strategy(),
         post: () => {
           FarmingStrategy.post?.();
           if (!have($effect`Everything looks Beige`)) updateParachuteFailure();
@@ -94,7 +94,7 @@ export function FarmTurnQuest(): Quest<
         prepare: farmPrepare,
         outfit: (context) => barfOutfit(FarmingStrategy.outfit(context)),
         do: FarmingStrategy.location,
-        combat: FarmingStrategy.combat,
+        combat: FarmingStrategy.strategy(),
         post: () => {
           FarmingStrategy.post?.();
           trackMarginalMpa();

--- a/packages/garbo/src/tasks/farm/farmTurn.ts
+++ b/packages/garbo/src/tasks/farm/farmTurn.ts
@@ -16,7 +16,11 @@ import {
   shouldCheckParachute,
   updateParachuteFailure,
 } from "./lib";
-import { averageRedTaffyValue, FarmingStrategy, redTaffyWorth } from "../../farmingStrategy";
+import {
+  averageRedTaffyValue,
+  FarmingStrategy,
+  redTaffyWorth,
+} from "../../farmingStrategy";
 import { trackMarginalMpa } from "../../session";
 import { meatMood } from "../../mood";
 import { estimatedGarboTurns } from "../../turns";

--- a/packages/garbo/src/tasks/farm/farmTurn.ts
+++ b/packages/garbo/src/tasks/farm/farmTurn.ts
@@ -16,13 +16,12 @@ import {
   shouldCheckParachute,
   updateParachuteFailure,
 } from "./lib";
-import { FarmingStrategy, redTaffyWorth } from "../../farmingStrategy";
+import { averageRedTaffyValue, FarmingStrategy, redTaffyWorth } from "../../farmingStrategy";
 import { trackMarginalMpa } from "../../session";
 import { meatMood } from "../../mood";
 import { estimatedGarboTurns } from "../../turns";
 import { barfOutfit } from "../../outfit";
 import { FarmingContext } from "../context";
-import { GarboStrategy } from "../../combatStrategy";
 import { acquire } from "../../acquire";
 
 export const farmPrepare = (context: FarmingContext) => {
@@ -59,27 +58,6 @@ export const farmPrepare = (context: FarmingContext) => {
   }
 };
 
-export const farmPost = () => {
-  FarmingStrategy.post?.();
-  trackMarginalMpa();
-
-  if (toMonster(get("lastEncounter")) === $monster`tumbleweed`) {
-    throw new Error(
-      "You encountered a tumbleweed and should not have, resolve your banishes",
-    );
-  }
-
-  if (
-    getMonstersToBanish(FarmingStrategy.banishMonsters).includes(
-      toMonster(get("lastEncounter")),
-    )
-  ) {
-    throw new Error(
-      "You encountered a banishable monster and didn't banish it, sort your life out!",
-    );
-  }
-};
-
 export function FarmTurnQuest(): Quest<
   GarboTask<FarmingContext>,
   FarmingContext
@@ -98,7 +76,7 @@ export function FarmTurnQuest(): Quest<
           have($effect`Everything looks Beige`) || myAdventures() === 0,
         outfit: (context) => barfOutfit(FarmingStrategy.outfit(context)),
         do: () => CrepeParachute.fight(undelay(FarmingStrategy.targetMonster)),
-        combat: new GarboStrategy((context) => FarmingStrategy.macro(context)),
+        combat: FarmingStrategy.combat,
         post: () => {
           FarmingStrategy.post?.();
           if (!have($effect`Everything looks Beige`)) updateParachuteFailure();

--- a/packages/garbo/src/tasks/farm/wanderer.ts
+++ b/packages/garbo/src/tasks/farm/wanderer.ts
@@ -87,7 +87,6 @@ import {
   willYachtzee,
 } from "../../resources";
 import { acquire } from "../../acquire";
-import { GarboContext } from "../context";
 import { bestYachtzeeFamiliar } from "../yachtzee/familiar";
 
 const isGhost = () => get("_voteMonster") === $monster`angry ghost`;

--- a/packages/garbo/src/tasks/farm/wanderer.ts
+++ b/packages/garbo/src/tasks/farm/wanderer.ts
@@ -88,6 +88,7 @@ import {
 } from "../../resources";
 import { acquire } from "../../acquire";
 import { bestYachtzeeFamiliar } from "../yachtzee/familiar";
+import { FarmingStrategy } from "../../farmingStrategy";
 
 const isGhost = () => get("_voteMonster") === $monster`angry ghost`;
 const isMutant = () => get("_voteMonster") === $monster`terrible mutant`;

--- a/packages/garbo/src/tasks/farm/wanderer.ts
+++ b/packages/garbo/src/tasks/farm/wanderer.ts
@@ -88,6 +88,7 @@ import {
 } from "../../resources";
 import { acquire } from "../../acquire";
 import { GarboContext } from "../context";
+import { bestYachtzeeFamiliar } from "../yachtzee/familiar";
 
 const isGhost = () => get("_voteMonster") === $monster`angry ghost`;
 const isMutant = () => get("_voteMonster") === $monster`terrible mutant`;
@@ -645,7 +646,6 @@ const BarfTurnTasks: GarboTask[] = [
       Macro.abortWithMsg("Hit unexpected combat!"),
     ),
     spendsTurn: true,
-    location: $location`The Sunken Party Yacht`,
   },
   {
     name: "Gingerbread Noon",

--- a/packages/garbo/src/tasks/farm/wanderer.ts
+++ b/packages/garbo/src/tasks/farm/wanderer.ts
@@ -761,7 +761,14 @@ const BarfTurnTasks: GarboTask[] = [
       const questMonster = get("_cookbookbatQuestMonster");
       if (!questMonster || hasNameCollision(questMonster)) return false;
       const questLocation = get("_cookbookbatQuestLastLocation");
-      if (!questLocation || !canAdventureOrUnlock(questLocation, false)) {
+      if (
+        !questLocation ||
+        !canAdventureOrUnlock(
+          questLocation,
+          false,
+          FarmingStrategy.isUnderwater(),
+        )
+      ) {
         return false;
       }
       const questReward = get("_cookbookbatQuestIngredient");

--- a/packages/garbo/src/tasks/farm/wanderer.ts
+++ b/packages/garbo/src/tasks/farm/wanderer.ts
@@ -626,6 +626,28 @@ const BarfTurnTasks: GarboTask[] = [
     },
   ),
   {
+    name: "Yachtzee (Cooldown ready)",
+    completed: () => get("encountersUntilYachtzeeChoice") > 0,
+    outfit: () => {
+      const spec: OutfitSpec = {
+        modifier: ["meat"],
+        familiar: bestYachtzeeFamiliar(),
+        avoid: $items`anemoney clip, cursed magnifying glass, Kramco Sausage-o-Matic™, cheap sunglasses, over-the-shoulder Folder Holder`,
+      };
+      if (!sober()) {
+        spec.equip = $items`Drunkula's wineglass`;
+      }
+      return spec;
+    },
+    do: $location`The Sunken Party Yacht`,
+    choices: { 918: 2 },
+    combat: new GarboStrategy(() =>
+      Macro.abortWithMsg("Hit unexpected combat!"),
+    ),
+    spendsTurn: true,
+    location: $location`The Sunken Party Yacht`,
+  },
+  {
     name: "Gingerbread Noon",
     completed: () => GingerBread.minutesToNoon() !== 0,
     do: $location`Gingerbread Train Station`,

--- a/packages/garbo/src/tasks/post/index.ts
+++ b/packages/garbo/src/tasks/post/index.ts
@@ -8,6 +8,7 @@ import {
   inebrietyLimit,
   Item,
   itemAmount,
+  Location,
   mallPrice,
   myAdventures,
   myFullness,
@@ -41,6 +42,7 @@ import {
   JuneCleaver,
   Leprecondo,
   maxBy,
+  realmAvailable,
   sum,
   undelay,
   uneffect,
@@ -75,7 +77,7 @@ import {
 import { farmingStrategy } from "../../farmingStrategy";
 import { GarboContext } from "../context";
 
-const STUFF_TO_CLOSET = $items`bowling ball, funky junk key`;
+const STUFF_TO_CLOSET = $items`bowling ball, funky junk key, sand dollar`;
 const STUFF_TO_USE = $items`Armory keycard, bottle-opener keycard, SHAWARMA Initiative Keycard`;
 
 function closetStuff(): GarboPostTask {
@@ -83,6 +85,7 @@ function closetStuff(): GarboPostTask {
     name: "Closet Stuff",
     completed: () => STUFF_TO_CLOSET.every((i) => itemAmount(i) === 0),
     do: () => STUFF_TO_CLOSET.forEach((i) => putCloset(itemAmount(i), i)),
+    post: () => cliExecute("refresh inventory"),
   };
 }
 
@@ -107,24 +110,32 @@ const BARF_PLANTS = () =>
         FloristFriar.PitcherPlant,
       ];
 function floristFriars(): GarboPostTask {
+  const primaryLocation = farmingStrategy().location;
+  const secondaryLocation =
+    farmingStrategy().location === $location`The Coral Corral` &&
+    realmAvailable("sleaze")
+      ? $location`The Sunken Party Yacht`
+      : Location.none;
+
+  const targetLocation =
+    secondaryLocation !== Location.none && FloristFriar.isFull(primaryLocation)
+      ? secondaryLocation
+      : primaryLocation;
+
   return {
     name: "Florist Plants",
-    completed: () => FloristFriar.isFull(farmingStrategy().location),
+    completed: () => FloristFriar.isFull(targetLocation),
     ready: () =>
-      get("lastAdventure") === farmingStrategy().location &&
+      get("lastAdventure") === targetLocation &&
       FloristFriar.have() &&
-      BARF_PLANTS().some((flower) =>
-        flower.available(farmingStrategy().location),
-      ),
+      BARF_PLANTS().some((flower) => flower.available(targetLocation)),
     do: () =>
       BARF_PLANTS()
-        .filter((flower) => flower.available(farmingStrategy().location))
+        .filter((flower) => flower.available(targetLocation))
         .forEach((flower) => flower.plant()),
     available: () =>
       FloristFriar.have() &&
-      BARF_PLANTS().some((flower) =>
-        flower.available(farmingStrategy().location),
-      ),
+      BARF_PLANTS().some((flower) => flower.available(targetLocation)),
   };
 }
 

--- a/packages/garbo/src/tasks/post/index.ts
+++ b/packages/garbo/src/tasks/post/index.ts
@@ -9,7 +9,6 @@ import {
   inebrietyLimit,
   Item,
   itemAmount,
-  Location,
   mallPrice,
   myAdventures,
   myFullness,
@@ -43,7 +42,6 @@ import {
   JuneCleaver,
   Leprecondo,
   maxBy,
-  realmAvailable,
   sum,
   undelay,
   uneffect,
@@ -130,7 +128,7 @@ function floristFriars(): GarboPostTask {
     completed: () =>
       FloristFriar.isFull(FarmingStrategy.location) || barfPlants.length === 0,
     ready: () =>
-      get("lastAdventure") === targetLocation &&
+      get("lastAdventure") === FarmingStrategy.location &&
       FloristFriar.have() &&
       barfPlants.some((flower) => flower.available(FarmingStrategy.location)),
     do: () =>

--- a/packages/garbo/src/tasks/yachtzee/index.ts
+++ b/packages/garbo/src/tasks/yachtzee/index.ts
@@ -1,7 +1,10 @@
 import {
   cliExecute,
   inebrietyLimit,
+  Item,
   myInebriety,
+  retrieveItem,
+  toMonster,
   use,
   useSkill,
 } from "kolmafia";
@@ -10,17 +13,17 @@ import {
   $item,
   $items,
   $location,
+  $monster,
   $skill,
   AprilingBandHelmet,
   CinchoDeMayo,
-  Delayed,
   get,
   have,
 } from "libram";
 import { bestFamUnderwaterGear, bestYachtzeeFamiliar } from "./familiar";
 import { getBestWaterBreathingEquipment } from "./lib";
 import { Macro } from "../../combat";
-import { GarboTask } from "../engine";
+import { AlternateTask } from "../engine";
 import { willDrunkAdventure } from "../../lib";
 import { Outfit, Quest } from "grimoire-kolmafia";
 import { maximumYachtzees, shouldClara, willYachtzee } from "../../resources";
@@ -29,11 +32,17 @@ import { barfOutfit } from "../../outfit";
 import { meatMood } from "../../mood";
 import { estimatedGarboTurns } from "../../turns";
 import { trackMarginalMpa } from "../../session";
-import { FarmingStrategy } from "../../farmingStrategy";
+import {
+  FarmingStrategy,
+  getMonstersToBanish,
+  redTaffyWorth,
+} from "../../farmingStrategy";
+import { FarmingContext } from "../context";
 
-type AlternateTask = GarboTask & { turns: Delayed<number> };
-
-export const yachtzeeQuest: Quest<AlternateTask>[] = [
+export const yachtzeeQuest: Quest<
+  AlternateTask<FarmingContext>,
+  FarmingContext
+>[] = [
   {
     name: "Yachtzee",
     completed: () => !willYachtzee() && !get("noncombatForcerActive"),
@@ -101,18 +110,55 @@ export const yachtzeeQuest: Quest<AlternateTask>[] = [
         completed: () => get("noncombatForcerActive"),
         ready: () =>
           have($item`Jurassic Parka`) && get("_spikolodonSpikeUses") < 5,
-        outfit: () =>
-          barfOutfit({
-            equip: $items`Jurassic Parka`,
-            modes: { parka: "spikolodon" },
-          }),
+        outfit: (context) => {
+          const baseOutfit = Outfit.from(
+            FarmingStrategy.outfit(context),
+            new Error("Failed to construct outfit"),
+          );
+          if (!baseOutfit.equip($items`Jurassic Parka`)) {
+            throw "Failed to complete outfit";
+          }
+          baseOutfit.setModes({ parka: "spikolodon" });
+          return barfOutfit(baseOutfit.spec());
+        },
         do: () => FarmingStrategy.location,
-        combat: new GarboStrategy(() =>
-          Macro.skill($skill`Launch spikolodon spikes`).meatKill(),
+        combat: new GarboStrategy((context) =>
+          Macro.skill($skill`Launch spikolodon spikes`).step(
+            FarmingStrategy.macro(context),
+          ),
         ),
-        prepare: () => meatMood().execute(estimatedGarboTurns()),
+        prepare: (context) => {
+          if (redTaffyWorth() && FarmingStrategy.isUnderwater()) {
+            retrieveItem($item`pulled red taffy`);
+          }
+          meatMood().execute(estimatedGarboTurns());
+
+          if (
+            context.banish?.retrieve &&
+            context.banish.source instanceof Item
+          ) {
+            retrieveItem(context.banish.source);
+          }
+        },
         post: () => {
+          FarmingStrategy.post?.();
           trackMarginalMpa();
+
+          if (toMonster(get("lastEncounter")) === $monster`tumbleweed`) {
+            throw new Error(
+              "You encountered a tumbleweed and should not have, resolve your banishes",
+            );
+          }
+
+          if (
+            getMonstersToBanish(FarmingStrategy.banishMonsters).includes(
+              toMonster(get("lastEncounter")),
+            )
+          ) {
+            throw new Error(
+              "You encountered a banishable monster and didn't banish it, sort your life out!",
+            );
+          }
         },
         turns: () => 2 * Math.max(0, 5 - get("_spikolodonSpikeUses")), // Need one turn to cast the NC, and one to do the yachtzee
         sobriety: "sober",
@@ -126,12 +172,43 @@ export const yachtzeeQuest: Quest<AlternateTask>[] = [
           get("_mcHugeLargeAvalancheUses") < 3,
         outfit: () => barfOutfit({ equip: $items`McHugeLarge left ski` }),
         do: () => FarmingStrategy.location,
-        combat: new GarboStrategy(() =>
-          Macro.skill($skill`McHugeLarge Avalanche`).meatKill(),
+        combat: new GarboStrategy((context) =>
+          Macro.skill($skill`McHugeLarge Avalanche`).step(
+            FarmingStrategy.macro(context),
+          ),
         ),
-        prepare: () => meatMood().execute(estimatedGarboTurns()),
+        prepare: (context) => {
+          if (redTaffyWorth() && FarmingStrategy.isUnderwater()) {
+            retrieveItem($item`pulled red taffy`);
+          }
+          meatMood().execute(estimatedGarboTurns());
+
+          if (
+            context.banish?.retrieve &&
+            context.banish.source instanceof Item
+          ) {
+            retrieveItem(context.banish.source);
+          }
+        },
         post: () => {
+          FarmingStrategy.post?.();
           trackMarginalMpa();
+
+          if (toMonster(get("lastEncounter")) === $monster`tumbleweed`) {
+            throw new Error(
+              "You encountered a tumbleweed and should not have, resolve your banishes",
+            );
+          }
+
+          if (
+            getMonstersToBanish(FarmingStrategy.banishMonsters).includes(
+              toMonster(get("lastEncounter")),
+            )
+          ) {
+            throw new Error(
+              "You encountered a banishable monster and didn't banish it, sort your life out!",
+            );
+          }
         },
         turns: () => 2 * Math.max(0, 3 - get("_mcHugeLargeAvalancheUses")), // Need one turn to cast the NC, and one to do the yachtzee
         sobriety: "sober",

--- a/packages/garbo/src/tasks/yachtzee/index.ts
+++ b/packages/garbo/src/tasks/yachtzee/index.ts
@@ -1,10 +1,7 @@
 import {
   cliExecute,
   inebrietyLimit,
-  Item,
   myInebriety,
-  retrieveItem,
-  toMonster,
   use,
   useSkill,
 } from "kolmafia";
@@ -13,7 +10,6 @@ import {
   $item,
   $items,
   $location,
-  $monster,
   $skill,
   AprilingBandHelmet,
   CinchoDeMayo,
@@ -29,15 +25,9 @@ import { Outfit, Quest } from "grimoire-kolmafia";
 import { maximumYachtzees, shouldClara, willYachtzee } from "../../resources";
 import { GarboStrategy } from "../../combatStrategy";
 import { barfOutfit } from "../../outfit";
-import { meatMood } from "../../mood";
-import { estimatedGarboTurns } from "../../turns";
-import { trackMarginalMpa } from "../../session";
-import {
-  FarmingStrategy,
-  getMonstersToBanish,
-  redTaffyWorth,
-} from "../../farmingStrategy";
+import { FarmingStrategy } from "../../farmingStrategy";
 import { FarmingContext } from "../context";
+import { farmPost, farmPrepare } from "../farm/farmTurn";
 
 export const yachtzeeQuest: Quest<
   AlternateTask<FarmingContext>,
@@ -127,39 +117,8 @@ export const yachtzeeQuest: Quest<
             FarmingStrategy.macro(context),
           ),
         ),
-        prepare: (context) => {
-          if (redTaffyWorth() && FarmingStrategy.isUnderwater()) {
-            retrieveItem($item`pulled red taffy`);
-          }
-          meatMood().execute(estimatedGarboTurns());
-
-          if (
-            context.banish?.retrieve &&
-            context.banish.source instanceof Item
-          ) {
-            retrieveItem(context.banish.source);
-          }
-        },
-        post: () => {
-          FarmingStrategy.post?.();
-          trackMarginalMpa();
-
-          if (toMonster(get("lastEncounter")) === $monster`tumbleweed`) {
-            throw new Error(
-              "You encountered a tumbleweed and should not have, resolve your banishes",
-            );
-          }
-
-          if (
-            getMonstersToBanish(FarmingStrategy.banishMonsters).includes(
-              toMonster(get("lastEncounter")),
-            )
-          ) {
-            throw new Error(
-              "You encountered a banishable monster and didn't banish it, sort your life out!",
-            );
-          }
-        },
+        prepare: farmPrepare,
+        post: farmPost,
         turns: () => 2 * Math.max(0, 5 - get("_spikolodonSpikeUses")), // Need one turn to cast the NC, and one to do the yachtzee
         sobriety: "sober",
         spendsTurn: true,
@@ -177,39 +136,8 @@ export const yachtzeeQuest: Quest<
             FarmingStrategy.macro(context),
           ),
         ),
-        prepare: (context) => {
-          if (redTaffyWorth() && FarmingStrategy.isUnderwater()) {
-            retrieveItem($item`pulled red taffy`);
-          }
-          meatMood().execute(estimatedGarboTurns());
-
-          if (
-            context.banish?.retrieve &&
-            context.banish.source instanceof Item
-          ) {
-            retrieveItem(context.banish.source);
-          }
-        },
-        post: () => {
-          FarmingStrategy.post?.();
-          trackMarginalMpa();
-
-          if (toMonster(get("lastEncounter")) === $monster`tumbleweed`) {
-            throw new Error(
-              "You encountered a tumbleweed and should not have, resolve your banishes",
-            );
-          }
-
-          if (
-            getMonstersToBanish(FarmingStrategy.banishMonsters).includes(
-              toMonster(get("lastEncounter")),
-            )
-          ) {
-            throw new Error(
-              "You encountered a banishable monster and didn't banish it, sort your life out!",
-            );
-          }
-        },
+        prepare: farmPrepare,
+        post: farmPost,
         turns: () => 2 * Math.max(0, 3 - get("_mcHugeLargeAvalancheUses")), // Need one turn to cast the NC, and one to do the yachtzee
         sobriety: "sober",
         spendsTurn: true,

--- a/packages/garbo/src/tasks/yachtzee/index.ts
+++ b/packages/garbo/src/tasks/yachtzee/index.ts
@@ -26,6 +26,11 @@ import { Outfit, Quest } from "grimoire-kolmafia";
 import { maximumYachtzees, shouldClara, willYachtzee } from "../../resources";
 import { GarboStrategy } from "../../combatStrategy";
 import { GarboContext } from "../context";
+import { barfOutfit } from "../../outfit";
+import { trackMarginalMpa } from "../../session";
+import { estimatedGarboTurns } from "../../turns";
+import { meatMood } from "../../mood";
+import { farmingStrategy } from "../../farmingStrategy";
 
 type AlternateTask = GarboTask & { turns: Delayed<number> };
 
@@ -91,6 +96,47 @@ export const yachtzeeQuest: Quest<AlternateTask, GarboContext>[] = [
         turns: 0,
         sobriety: () => (willDrunkAdventure() ? "drunk" : "sober"),
         spendsTurn: false,
+      },
+      {
+        name: "Parka Spikes NC Forcer",
+        completed: () => get("noncombatForcerActive"),
+        ready: () =>
+          have($item`Jurassic Parka`) && get("_spikolodonSpikeUses") < 5,
+        outfit: () =>
+          barfOutfit({
+            equip: $items`Jurassic Parka`,
+            modes: { parka: "spikolodon" },
+          }),
+        do: farmingStrategy().location,
+        combat: new GarboStrategy(() =>
+          Macro.skill($skill`Launch spikolodon spikes`).meatKill(),
+        ),
+        prepare: () => meatMood().execute(estimatedGarboTurns()),
+        post: () => {
+          trackMarginalMpa();
+        },
+        turns: () => 2 * Math.max(0, 5 - get("_spikolodonSpikeUses")), // Need one turn to cast the NC, and one to do the yachtzee
+        sobriety: "sober",
+        spendsTurn: true,
+      },
+      {
+        name: "McHugeLarge Avalanche NC Forcer",
+        completed: () => get("noncombatForcerActive"),
+        ready: () =>
+          have($item`McHugeLarge left ski`) &&
+          get("_mcHugeLargeAvalancheUses") < 3,
+        outfit: () => barfOutfit({ equip: $items`McHugeLarge left ski` }),
+        do: farmingStrategy().location,
+        combat: new GarboStrategy(() =>
+          Macro.skill($skill`McHugeLarge Avalanche`).meatKill(),
+        ),
+        prepare: () => meatMood().execute(estimatedGarboTurns()),
+        post: () => {
+          trackMarginalMpa();
+        },
+        turns: () => 2 * Math.max(0, 3 - get("_mcHugeLargeAvalancheUses")), // Need one turn to cast the NC, and one to do the yachtzee
+        sobriety: "sober",
+        spendsTurn: true,
       },
       {
         name: "Apriling Band Tuba Yachtzee NC Force",

--- a/packages/garbo/src/tasks/yachtzee/index.ts
+++ b/packages/garbo/src/tasks/yachtzee/index.ts
@@ -27,7 +27,7 @@ import { GarboStrategy } from "../../combatStrategy";
 import { barfOutfit } from "../../outfit";
 import { FarmingStrategy } from "../../farmingStrategy";
 import { FarmingContext } from "../context";
-import { farmPost, farmPrepare } from "../farm/farmTurn";
+import { farmPrepare } from "../farm/farmTurn";
 
 export const yachtzeeQuest: Quest<
   AlternateTask<FarmingContext>,
@@ -112,13 +112,11 @@ export const yachtzeeQuest: Quest<
           return barfOutfit(baseOutfit.spec());
         },
         do: () => FarmingStrategy.location,
-        combat: new GarboStrategy((context) =>
-          Macro.skill($skill`Launch spikolodon spikes`).step(
-            FarmingStrategy.macro(context),
-          ),
+        combat: FarmingStrategy.combat.clone().startingMacro(
+          Macro.skill($skill`Launch spikolodon spikes`),
         ),
         prepare: farmPrepare,
-        post: farmPost,
+        post: FarmingStrategy.post,
         turns: () => 2 * Math.max(0, 5 - get("_spikolodonSpikeUses")), // Need one turn to cast the NC, and one to do the yachtzee
         sobriety: "sober",
         spendsTurn: true,
@@ -131,13 +129,11 @@ export const yachtzeeQuest: Quest<
           get("_mcHugeLargeAvalancheUses") < 3,
         outfit: () => barfOutfit({ equip: $items`McHugeLarge left ski` }),
         do: () => FarmingStrategy.location,
-        combat: new GarboStrategy((context) =>
-          Macro.skill($skill`McHugeLarge Avalanche`).step(
-            FarmingStrategy.macro(context),
-          ),
+        combat: FarmingStrategy.combat.clone().startingMacro(
+          Macro.skill($skill`McHugeLarge Avalanche`),
         ),
         prepare: farmPrepare,
-        post: farmPost,
+        post: FarmingStrategy.post,
         turns: () => 2 * Math.max(0, 3 - get("_mcHugeLargeAvalancheUses")), // Need one turn to cast the NC, and one to do the yachtzee
         sobriety: "sober",
         spendsTurn: true,

--- a/packages/garbo/src/tasks/yachtzee/index.ts
+++ b/packages/garbo/src/tasks/yachtzee/index.ts
@@ -112,9 +112,7 @@ export const yachtzeeQuest: Quest<
           return barfOutfit(baseOutfit.spec());
         },
         do: () => FarmingStrategy.location,
-        combat: FarmingStrategy.combat
-          .clone()
-          .startingMacro(Macro.skill($skill`Launch spikolodon spikes`)),
+        combat: FarmingStrategy.strategy(),
         prepare: farmPrepare,
         post: FarmingStrategy.post,
         turns: () => 2 * Math.max(0, 5 - get("_spikolodonSpikeUses")), // Need one turn to cast the NC, and one to do the yachtzee
@@ -129,9 +127,7 @@ export const yachtzeeQuest: Quest<
           get("_mcHugeLargeAvalancheUses") < 3,
         outfit: () => barfOutfit({ equip: $items`McHugeLarge left ski` }),
         do: () => FarmingStrategy.location,
-        combat: FarmingStrategy.combat
-          .clone()
-          .startingMacro(Macro.skill($skill`McHugeLarge Avalanche`)),
+        combat: FarmingStrategy.strategy(),
         prepare: farmPrepare,
         post: FarmingStrategy.post,
         turns: () => 2 * Math.max(0, 3 - get("_mcHugeLargeAvalancheUses")), // Need one turn to cast the NC, and one to do the yachtzee

--- a/packages/garbo/src/tasks/yachtzee/index.ts
+++ b/packages/garbo/src/tasks/yachtzee/index.ts
@@ -112,9 +112,9 @@ export const yachtzeeQuest: Quest<
           return barfOutfit(baseOutfit.spec());
         },
         do: () => FarmingStrategy.location,
-        combat: FarmingStrategy.combat.clone().startingMacro(
-          Macro.skill($skill`Launch spikolodon spikes`),
-        ),
+        combat: FarmingStrategy.combat
+          .clone()
+          .startingMacro(Macro.skill($skill`Launch spikolodon spikes`)),
         prepare: farmPrepare,
         post: FarmingStrategy.post,
         turns: () => 2 * Math.max(0, 5 - get("_spikolodonSpikeUses")), // Need one turn to cast the NC, and one to do the yachtzee
@@ -129,9 +129,9 @@ export const yachtzeeQuest: Quest<
           get("_mcHugeLargeAvalancheUses") < 3,
         outfit: () => barfOutfit({ equip: $items`McHugeLarge left ski` }),
         do: () => FarmingStrategy.location,
-        combat: FarmingStrategy.combat.clone().startingMacro(
-          Macro.skill($skill`McHugeLarge Avalanche`),
-        ),
+        combat: FarmingStrategy.combat
+          .clone()
+          .startingMacro(Macro.skill($skill`McHugeLarge Avalanche`)),
         prepare: farmPrepare,
         post: FarmingStrategy.post,
         turns: () => 2 * Math.max(0, 3 - get("_mcHugeLargeAvalancheUses")), // Need one turn to cast the NC, and one to do the yachtzee


### PR DESCRIPTION
General thoughts while I was doing this:

- Are we running underwater potions during embezzlers/copy targets? What about meat mood? We don't want to run pressure penalty stuff here even if we're flooding because the pressure penalty is already 0

- Pill keeper opportunity cost? Is that old yachtzee?

-For enabling underwater wandering, how can we check whether our farming strategy is underwater from within wanderer?

- Are we properly setting location before maximizing? Are we just purely relying on +sea? This is important for wandering probably

- Some way to value resistances while wandering for pearls?

- What happened to our dinseyRollercoasterNext check? I can't seem to find it anymore

- Is there anything we might want to do during nobarf if we do have fishy, but our farming strategy isn't cows?

- Can we better integrate the combat NC forcers for yachtzee somehow with farmingStrategy? can't use farmingStrategy().combat to put something after the skill usage

How can I make it so VALUABLE_MODIFIERS only includes Hidden Familiar Weight if we're going to go underwater?