### PR TITLE
misc improvements (mostly cowo related)

### DIFF
--- a/packages/garbo/src/config.ts
+++ b/packages/garbo/src/config.ts
@@ -246,6 +246,11 @@ You can use multiple options in conjunction, e.g. "garbo nobarf ascend"',
           help: "This is used only when autoUserConfirm is true, will automatically use resources (such as pocket wishes, 11-leaf clovers, etc) up to this threshold to source a target monster for chaining before requesting user interference.",
           default: 1,
         }),
+        autoWishProfitThreshold: Args.number({
+          setting: "garbo_autoWishProfitThreshold",
+          help: "If 0 or greater, skip the confirmation dialog and wish for your copy target automatically whenever we have copies banked but no way to start a chain, and the expected profit (in meat, after paying for the wish) is at least this large. Negative values (the default) always ask. Genie fights remain capped at 3 per day.",
+          default: -1,
+        }),
         restoreHpTarget: Args.number({
           setting: "garbo_restoreHpTarget",
           help: "If you're a very high level, what HP threshold should garbo aim to maintain?",

--- a/packages/garbo/src/config.ts
+++ b/packages/garbo/src/config.ts
@@ -220,6 +220,11 @@ You can use multiple options in conjunction, e.g. "garbo nobarf ascend"',
           setting: "garbo_skipAscensionCheck",
           help: "Set to true to skip verifying that your account has broken the prism, otherwise you will be warned upon starting the script.",
         }),
+        skipOverdrunkAdventures: Args.boolean({
+          setting: "garbo_skipOverdrunkAdventures",
+          help: "Set to true to stop garbo adventuring with Drunkula's wineglass while overdrunk. It still runs everything that does not cost a turn, so the day is finished rather than abandoned.",
+          default: false,
+        }),
         fightGlitch: Args.boolean({
           setting: "garbo_fightGlitch",
           help: "Set to true to fight the glitch season reward. You need certain skills, see relay for info.",

--- a/packages/garbo/src/familiar/lib.ts
+++ b/packages/garbo/src/familiar/lib.ts
@@ -126,13 +126,14 @@ export function canOpenRedPresent(): boolean {
 export function turnsAvailable(): number {
   const baseTurns = estimatedGarboTurns();
   const digitizes = wanderingCopytargetsRemaining();
-  const mapTurns = globalOptions.ascend
-    ? clamp(
-        availableAmount($item`Map to Safety Shelter Grimace Prime`),
-        0,
-        ESTIMATED_OVERDRUNK_TURNS,
-      )
-    : 0;
+  const mapTurns =
+    globalOptions.ascend && !globalOptions.prefs.skipOverdrunkAdventures
+      ? clamp(
+          availableAmount($item`Map to Safety Shelter Grimace Prime`),
+          0,
+          ESTIMATED_OVERDRUNK_TURNS,
+        )
+      : 0;
 
   const barfTurns = baseTurns - digitizes - mapTurns;
   const barfCombatRate = 1 - 1 / turnsToNC;

--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -13,6 +13,7 @@ import {
   equippedItem,
   familiarEquippedEquipment,
   getAutoAttack,
+  handlingChoice,
   haveOutfit,
   inebrietyLimit,
   isBanished,
@@ -186,7 +187,7 @@ import {
   expectedFreeGiantSandwormQuestFights,
   FreeGiantSandwormQuest,
 } from "./tasks/freeGiantSandworm";
-import { CopyTargetFight } from "./target/fights";
+import { CopyTargetFight, escapeRefusedTimeSpinner } from "./target/fights";
 import {
   BuffExtensionQuest,
   PostBuffExtensionQuest,
@@ -808,6 +809,14 @@ function molemanReady() {
   return have($item`molehill mountain`) && !get("_molehillMountainUsed");
 }
 
+/**
+ * Whether the Time-Spinner has already declined to travel to a drunk pygmy.
+ *
+ * The bowling alley's `combatQueue` only approximates the Time-Spinner's
+ * recent-fight list, so a pygmy can pass `available()` and still not be on offer.
+ */
+let timeSpinnerRefusedPygmy = false;
+
 const freeFightSources = [
   new FreeFight(
     () => (wantPills() ? 5 - get("_saberForceUses") : 0),
@@ -1037,6 +1046,7 @@ const freeFightSources = [
 
   new FreeFight(
     () =>
+      !timeSpinnerRefusedPygmy &&
       have($item`Time-Spinner`) &&
       !doingGregFight() &&
       $location`The Hidden Bowling Alley`.combatQueue.includes("drunk pygmy") &&
@@ -1051,6 +1061,13 @@ const freeFightSources = [
       visitUrl(
         `choice.php?whichchoice=1196&monid=${$monster`drunk pygmy`.id}&option=1`,
       );
+      // A successful spin puts us in combat. Still sitting in a choice means the
+      // travel was refused, and a refusal does not spend any minutes, so nothing
+      // stops available() offering this again on the same stale queue entry.
+      if (handlingChoice()) {
+        timeSpinnerRefusedPygmy = true;
+        escapeRefusedTimeSpinner($monster`drunk pygmy`);
+      }
     },
     true,
     pygmyOptions(),

--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -187,7 +187,11 @@ import {
   expectedFreeGiantSandwormQuestFights,
   FreeGiantSandwormQuest,
 } from "./tasks/freeGiantSandworm";
-import { CopyTargetFight, escapeRefusedTimeSpinner } from "./target/fights";
+import {
+  CopyTargetFight,
+  escapeRefusedTimeSpinner,
+  timeSpinnerOffers,
+} from "./target/fights";
 import {
   BuffExtensionQuest,
   PostBuffExtensionQuest,
@@ -1053,6 +1057,20 @@ const freeFightSources = [
         .setAutoAttack();
       visitUrl(`inv_use.php?whichitem=${toInt($item`Time-Spinner`)}`);
       runChoice(1);
+      const offered = timeSpinnerOffers($monster`drunk pygmy`);
+      if (offered === false) {
+        // Ground truth says no pygmy is on the list; don't submit a travel
+        // that is certain to be refused.
+        timeSpinnerRefusedPygmy = true;
+        escapeRefusedTimeSpinner($monster`drunk pygmy`);
+        return;
+      }
+      if (offered === null) {
+        print(
+          "Could not find the Time-Spinner's recent-fight list on the page; attempting the travel anyway.",
+          HIGHLIGHT,
+        );
+      }
       visitUrl(
         `choice.php?whichchoice=1196&monid=${$monster`drunk pygmy`.id}&option=1`,
       );

--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -1059,8 +1059,7 @@ const freeFightSources = [
       runChoice(1);
       const offered = timeSpinnerOffers($monster`drunk pygmy`);
       if (offered === false) {
-        // Ground truth says no pygmy is on the list; don't submit a travel
-        // that is certain to be refused.
+        // Not on the list; don't submit a travel that will be refused.
         timeSpinnerRefusedPygmy = true;
         escapeRefusedTimeSpinner($monster`drunk pygmy`);
         return;
@@ -1074,8 +1073,7 @@ const freeFightSources = [
       visitUrl(
         `choice.php?whichchoice=1196&monid=${$monster`drunk pygmy`.id}&option=1`,
       );
-      // Still in a choice means the travel was refused. A refusal spends no
-      // minutes, so latch it off or available() keeps re-offering it.
+      // Refusals spend no minutes, so latch it off or available() re-offers.
       if (handlingChoice()) {
         timeSpinnerRefusedPygmy = true;
         escapeRefusedTimeSpinner($monster`drunk pygmy`);

--- a/packages/garbo/src/fights.ts
+++ b/packages/garbo/src/fights.ts
@@ -809,12 +809,7 @@ function molemanReady() {
   return have($item`molehill mountain`) && !get("_molehillMountainUsed");
 }
 
-/**
- * Whether the Time-Spinner has already declined to travel to a drunk pygmy.
- *
- * The bowling alley's `combatQueue` only approximates the Time-Spinner's
- * recent-fight list, so a pygmy can pass `available()` and still not be on offer.
- */
+/** Whether the Time-Spinner has already declined to travel to a drunk pygmy. */
 let timeSpinnerRefusedPygmy = false;
 
 const freeFightSources = [
@@ -1061,9 +1056,8 @@ const freeFightSources = [
       visitUrl(
         `choice.php?whichchoice=1196&monid=${$monster`drunk pygmy`.id}&option=1`,
       );
-      // A successful spin puts us in combat. Still sitting in a choice means the
-      // travel was refused, and a refusal does not spend any minutes, so nothing
-      // stops available() offering this again on the same stale queue entry.
+      // Still in a choice means the travel was refused. A refusal spends no
+      // minutes, so latch it off or available() keeps re-offering it.
       if (handlingChoice()) {
         timeSpinnerRefusedPygmy = true;
         escapeRefusedTimeSpinner($monster`drunk pygmy`);

--- a/packages/garbo/src/index.ts
+++ b/packages/garbo/src/index.ts
@@ -73,6 +73,7 @@ import {
   propertyManager,
   questStep,
   safeRestore,
+  skippingOverdrunkAdventures,
   targetingMeat,
   userConfirmDialog,
   valueDrops,
@@ -609,7 +610,19 @@ export function main(argString = ""): void {
         runGarboQuests([SetupTargetCopyQuest]);
         dailyFights();
 
-        if (!globalOptions.nobarf) {
+        if (!globalOptions.nobarf && skippingOverdrunkAdventures()) {
+          // 3. overdrunk with the wineglass benched: no turns to buff for, but
+          // the end of day tasks still need to run
+          print(
+            "Overdrunk and garbo_skipOverdrunkAdventures is set, so finishing up without adventuring.",
+            HIGHLIGHT,
+          );
+          try {
+            runGarboQuests([FinishUpQuest]);
+          } finally {
+            setAutoAttack(0);
+          }
+        } else if (!globalOptions.nobarf) {
           // 3. burn turns at barf
           potionSetup(false);
           maximize("MP", false);

--- a/packages/garbo/src/lib.ts
+++ b/packages/garbo/src/lib.ts
@@ -1204,7 +1204,15 @@ export function improvesAStat(thing: Item | Effect): boolean {
 }
 
 export function willDrunkAdventure() {
-  return have($item`Drunkula's wineglass`) && globalOptions.ascend;
+  return (
+    have($item`Drunkula's wineglass`) &&
+    globalOptions.ascend &&
+    !globalOptions.prefs.skipOverdrunkAdventures
+  );
+}
+
+export function skippingOverdrunkAdventures(): boolean {
+  return globalOptions.prefs.skipOverdrunkAdventures && !sober();
 }
 
 export function freeFishyAvailable(): boolean {

--- a/packages/garbo/src/outfit/dropsgearAccessories.ts
+++ b/packages/garbo/src/outfit/dropsgearAccessories.ts
@@ -3,7 +3,6 @@ import {
   itemAmount,
   Modifier,
   myClass,
-  setLocation,
   stringModifier,
   toSlot,
 } from "kolmafia";
@@ -30,6 +29,7 @@ import {
   maxPassiveDamage,
   modeIsFree,
   monsterManuelAvailable,
+  withLocation,
 } from "../lib";
 import { maximumPinataCasts } from "../resources";
 import { globalOptions } from "../config";
@@ -210,21 +210,24 @@ export function usingThumbRing(): boolean {
     const gear = bonusAccessories(BonusEquipMode.BARF);
     const accessoryBonuses = [...gear.entries()].filter(([item]) => have(item));
 
-    setLocation($location`Barf Mountain`);
-    const meatAccessories = Item.all()
-      .filter(
-        (item) =>
-          have(item) &&
-          toSlot(item) === $slot`acc1` &&
-          getModifier("Meat Drop", item) > 0,
-      )
-      .map(
-        (item) =>
-          [item, (getModifier("Meat Drop", item) * baseMeat()) / 100] as [
-            Item,
-            number,
-          ],
-      );
+    // Mafia resolves env()/zone()/loc() modifiers against the last location
+    // set, so restore it or unrelated gear is priced against this one.
+    const meatAccessories = withLocation($location`Barf Mountain`, () =>
+      Item.all()
+        .filter(
+          (item) =>
+            have(item) &&
+            toSlot(item) === $slot`acc1` &&
+            getModifier("Meat Drop", item) > 0,
+        )
+        .map(
+          (item) =>
+            [item, (getModifier("Meat Drop", item) * baseMeat()) / 100] as [
+              Item,
+              number,
+            ],
+        ),
+    );
 
     const accessoryValues = new Map<Item, number>(accessoryBonuses);
     for (const [accessory, value] of meatAccessories) {

--- a/packages/garbo/src/target/fights.ts
+++ b/packages/garbo/src/target/fights.ts
@@ -2,9 +2,11 @@ import {
   abort,
   canAdventure,
   getClanLounge,
+  handlingChoice,
   haveEquipped,
   isBanished,
   itemAmount,
+  lastChoice,
   Location,
   myAdventures,
   myHash,
@@ -262,16 +264,53 @@ export const chainStarters = [
   ),
 ];
 
+const TRAVEL_TO_A_RECENT_FIGHT = 1196;
+
+/**
+ * Whether the Time-Spinner has already declined to travel to our target this run.
+ *
+ * `combatQueue` is only an approximation of the Time-Spinner's recent-fight list, so
+ * the target can pass our `available()` check and still not be on offer. When that
+ * happens the game does not start a fight -- it just hands choice 1196 back -- and
+ * we would otherwise keep spending the item on a list that will not have our target.
+ */
+let timeSpinnerRefusedTarget = false;
+
+/**
+ * Leave choice 1196 after the Time-Spinner declined to fight our target.
+ *
+ * This matters well beyond the wasted attempt: mafia cannot change equipment while a
+ * choice is open, so an abandoned 1196 surfaces much later as "Failed to maximize
+ * properly!" from whichever unrelated task next dresses an outfit.
+ */
+function escapeRefusedTimeSpinner(): void {
+  timeSpinnerRefusedTarget = true;
+  print(
+    `The Time-Spinner would not travel to a ${globalOptions.target}; it is no longer in the recent-fight list. Backing out of the choice and skipping this source for the rest of the run.`,
+    HIGHLIGHT,
+  );
+  if (handlingChoice() && lastChoice() === TRAVEL_TO_A_RECENT_FIGHT) {
+    runChoice(2); // Maybe Later
+  }
+  if (handlingChoice()) {
+    abort(
+      `Still stuck in choice ${lastChoice()} after the Time-Spinner refused to fight a ${globalOptions.target}. Resolve it in the relay browser before continuing -- leaving a choice open breaks every later equipment change.`,
+    );
+  }
+}
+
 export const copySources = [
   new CopyTargetFight(
     "Time-Spinner",
     () =>
+      !timeSpinnerRefusedTarget &&
       have($item`Time-Spinner`) &&
       $locations`Noob Cave, The Dire Warren, The Haunted Kitchen`.some(
         (location) => location.combatQueue.includes(globalOptions.target.name),
       ) &&
       get("_timeSpinnerMinutesUsed") <= 7,
     () =>
+      !timeSpinnerRefusedTarget &&
       have($item`Time-Spinner`) &&
       $locations`Noob Cave, The Dire Warren, The Haunted Kitchen`.some(
         (location) =>
@@ -287,8 +326,14 @@ export const copySources = [
           directlyUse($item`Time-Spinner`);
           runChoice(1);
           visitUrl(
-            `choice.php?whichchoice=1196&monid=${globalOptions.target.id}&option=1`,
+            `choice.php?whichchoice=${TRAVEL_TO_A_RECENT_FIGHT}&monid=${globalOptions.target.id}&option=1`,
           );
+          // A successful spin puts us in combat. If we are still sitting in a
+          // choice then the travel was refused and there is no fight to run.
+          if (handlingChoice()) {
+            escapeRefusedTimeSpinner();
+            return;
+          }
           runCombat();
         },
         options.useAuto,

--- a/packages/garbo/src/target/fights.ts
+++ b/packages/garbo/src/target/fights.ts
@@ -284,12 +284,8 @@ function targetInCombatQueue(): boolean {
 }
 
 /**
- * From inside choice 1196, whether a monster is on the Time-Spinner's offer
- * list -- the ground truth that `combatQueue` only approximates.
- *
- * Reads mafia's parse of the current choice form rather than the page markup;
- * the list is a <select name="monid"> whose keys are monster ids (with a "0"
- * placeholder).
+ * Whether a monster is on the Time-Spinner's offer list, read from the
+ * <select name="monid"> in choice 1196.
  * @param monster The monster to look for
  * @returns Whether the monster is offered, or null if no list was found
  */
@@ -308,10 +304,8 @@ export function timeSpinnerOffers(monster: Monster): boolean | null {
 let timeSpinnerRefusedTarget = false;
 
 /**
- * Leave the Time-Spinner choice after it declined to travel to a monster.
- *
- * An open choice blocks every later equipment change, so leaving one surfaces
- * far away as "Failed to maximize properly!".
+ * Leave the Time-Spinner choice after a refused travel. An open choice blocks
+ * every later equipment change.
  * @param monster The monster the Time-Spinner would not travel to
  */
 export function escapeRefusedTimeSpinner(monster: Monster): void {
@@ -319,9 +313,8 @@ export function escapeRefusedTimeSpinner(monster: Monster): void {
     `The Time-Spinner would not travel to a ${monster}; it is no longer in the recent-fight list. Backing out of the choice.`,
     HIGHLIGHT,
   );
-  // Leaving one Time-Spinner page can land on the other, so drain both. 1196 is
-  // not in mafia's canWalkFromChoice table and needs its "Maybe Later"; 1195 is,
-  // so any non-choice request drops it.
+  // A refusal can bounce between the two pages, so drain both: 1196 needs its
+  // "Maybe Later" option, 1195 walks away on any non-choice request.
   let attempts = 0;
   while (handlingChoice() && attempts++ < 3) {
     const choice = lastChoice();
@@ -336,7 +329,7 @@ export function escapeRefusedTimeSpinner(monster: Monster): void {
 
   if (handlingChoice()) {
     abort(
-      `Still stuck in choice ${lastChoice()} after the Time-Spinner refused to fight a ${monster}. Resolve it in the relay browser before continuing -- leaving a choice open breaks every later equipment change.`,
+      `Still stuck in choice ${lastChoice()} after the Time-Spinner refused to fight a ${monster}. Resolve it in the relay browser before continuing.`,
     );
   }
 }
@@ -363,8 +356,7 @@ export const copySources = [
           runChoice(1);
           const offered = timeSpinnerOffers(globalOptions.target);
           if (offered === false) {
-            // Ground truth says the target is not on the list; don't submit a
-            // travel that is certain to be refused.
+            // Not on the list; don't submit a travel that will be refused.
             timeSpinnerRefusedTarget = true;
             escapeRefusedTimeSpinner(globalOptions.target);
             return;

--- a/packages/garbo/src/target/fights.ts
+++ b/packages/garbo/src/target/fights.ts
@@ -1,5 +1,6 @@
 import {
   abort,
+  availableChoiceSelectInputs,
   canAdventure,
   getClanLounge,
   handlingChoice,
@@ -282,6 +283,27 @@ function targetInCombatQueue(): boolean {
   );
 }
 
+/**
+ * From inside choice 1196, whether a monster is on the Time-Spinner's offer
+ * list -- the ground truth that `combatQueue` only approximates.
+ *
+ * Reads mafia's parse of the current choice form rather than the page markup;
+ * the list is a <select name="monid"> whose keys are monster ids (with a "0"
+ * placeholder).
+ * @param monster The monster to look for
+ * @returns Whether the monster is offered, or null if no list was found
+ */
+export function timeSpinnerOffers(monster: Monster): boolean | null {
+  const monids = availableChoiceSelectInputs(1)["monid"];
+  if (!monids || Object.keys(monids).length === 0) return null;
+  if (`${monster.id}` in monids) return true;
+  print(
+    `The Time-Spinner is only offering: ${Object.values(monids).join(", ")}`,
+    HIGHLIGHT,
+  );
+  return false;
+}
+
 /** Whether the Time-Spinner has already declined to travel to our target. */
 let timeSpinnerRefusedTarget = false;
 
@@ -339,6 +361,20 @@ export const copySources = [
         () => {
           directlyUse($item`Time-Spinner`);
           runChoice(1);
+          const offered = timeSpinnerOffers(globalOptions.target);
+          if (offered === false) {
+            // Ground truth says the target is not on the list; don't submit a
+            // travel that is certain to be refused.
+            timeSpinnerRefusedTarget = true;
+            escapeRefusedTimeSpinner(globalOptions.target);
+            return;
+          }
+          if (offered === null) {
+            print(
+              "Could not find the Time-Spinner's recent-fight list on the page; attempting the travel anyway.",
+              HIGHLIGHT,
+            );
+          }
           visitUrl(
             `choice.php?whichchoice=${TRAVEL_TO_A_RECENT_FIGHT}&monid=${globalOptions.target.id}&option=1`,
           );

--- a/packages/garbo/src/target/fights.ts
+++ b/packages/garbo/src/target/fights.ts
@@ -8,6 +8,7 @@ import {
   itemAmount,
   lastChoice,
   Location,
+  Monster,
   myAdventures,
   myHash,
   myRain,
@@ -266,6 +267,21 @@ export const chainStarters = [
 
 const SPINNING_YOUR_TIME_SPINNER = 1195;
 const TRAVEL_TO_A_RECENT_FIGHT = 1196;
+const TIME_SPINNER_LOCATIONS = $locations`Noob Cave, The Dire Warren, The Haunted Kitchen`;
+
+/**
+ * Whether the target is in a combat queue the Time-Spinner draws from.
+ *
+ * `combatQueue` is a "; "-joined list, so match its entries rather than testing
+ * for a substring -- a substring test claims a sea cow when only a sea cowboy
+ * was fought.
+ * @returns Whether the target is in one of those queues
+ */
+function targetInCombatQueue(): boolean {
+  return TIME_SPINNER_LOCATIONS.some((location) =>
+    location.combatQueue.split("; ").includes(globalOptions.target.name),
+  );
+}
 
 /**
  * Whether the Time-Spinner has already declined to travel to our target this run.
@@ -278,23 +294,23 @@ const TRAVEL_TO_A_RECENT_FIGHT = 1196;
 let timeSpinnerRefusedTarget = false;
 
 /**
- * Leave choice 1196 after the Time-Spinner declined to fight our target.
+ * Leave the Time-Spinner choice after it declined to travel to a monster.
  *
  * This matters well beyond the wasted attempt: mafia cannot change equipment while a
  * choice is open, so an abandoned 1196 surfaces much later as "Failed to maximize
  * properly!" from whichever unrelated task next dresses an outfit.
+ * @param monster The monster the Time-Spinner would not travel to
  */
-function escapeRefusedTimeSpinner(): void {
-  timeSpinnerRefusedTarget = true;
+export function escapeRefusedTimeSpinner(monster: Monster): void {
   print(
-    `The Time-Spinner would not travel to a ${globalOptions.target}; it is no longer in the recent-fight list. Backing out of the choice and skipping this source for the rest of the run.`,
+    `The Time-Spinner would not travel to a ${monster}; it is no longer in the recent-fight list. Backing out of the choice.`,
     HIGHLIGHT,
   );
-  // A refusal can leave us on either Time-Spinner page -- in practice it bounces
-  // back to the 1195 menu -- and leaving one lands on the other, so drain them
-  // rather than handling a single hop. 1196 is not in mafia's canWalkFromChoice
-  // table and needs its explicit "Maybe Later"; 1195 is, so any non-choice
-  // request drops it and ChoiceManager clears handlingChoice for us.
+  // A refusal hands 1196 back, and leaving one Time-Spinner page can land on the
+  // other, so drain both rather than handling a single hop. 1196 is not in
+  // mafia's canWalkFromChoice table and needs its explicit "Maybe Later"; 1195
+  // is, so any non-choice request drops it and ChoiceManager clears
+  // handlingChoice for us.
   let attempts = 0;
   while (handlingChoice() && attempts++ < 3) {
     const choice = lastChoice();
@@ -309,7 +325,7 @@ function escapeRefusedTimeSpinner(): void {
 
   if (handlingChoice()) {
     abort(
-      `Still stuck in choice ${lastChoice()} after the Time-Spinner refused to fight a ${globalOptions.target}. Resolve it in the relay browser before continuing -- leaving a choice open breaks every later equipment change.`,
+      `Still stuck in choice ${lastChoice()} after the Time-Spinner refused to fight a ${monster}. Resolve it in the relay browser before continuing -- leaving a choice open breaks every later equipment change.`,
     );
   }
 }
@@ -320,18 +336,12 @@ export const copySources = [
     () =>
       !timeSpinnerRefusedTarget &&
       have($item`Time-Spinner`) &&
-      $locations`Noob Cave, The Dire Warren, The Haunted Kitchen`.some(
-        (location) => location.combatQueue.includes(globalOptions.target.name),
-      ) &&
+      targetInCombatQueue() &&
       get("_timeSpinnerMinutesUsed") <= 7,
     () =>
       !timeSpinnerRefusedTarget &&
       have($item`Time-Spinner`) &&
-      $locations`Noob Cave, The Dire Warren, The Haunted Kitchen`.some(
-        (location) =>
-          location.combatQueue.includes(globalOptions.target.name) ||
-          totalGregCharges(true),
-      )
+      (targetInCombatQueue() || totalGregCharges(true) > 0)
         ? Math.floor((10 - get("_timeSpinnerMinutesUsed")) / 3)
         : 0,
     (options: RunOptions) => {
@@ -346,7 +356,8 @@ export const copySources = [
           // A successful spin puts us in combat. If we are still sitting in a
           // choice then the travel was refused and there is no fight to run.
           if (handlingChoice()) {
-            escapeRefusedTimeSpinner();
+            timeSpinnerRefusedTarget = true;
+            escapeRefusedTimeSpinner(globalOptions.target);
             return;
           }
           runCombat();

--- a/packages/garbo/src/target/fights.ts
+++ b/packages/garbo/src/target/fights.ts
@@ -264,6 +264,7 @@ export const chainStarters = [
   ),
 ];
 
+const SPINNING_YOUR_TIME_SPINNER = 1195;
 const TRAVEL_TO_A_RECENT_FIGHT = 1196;
 
 /**
@@ -289,9 +290,23 @@ function escapeRefusedTimeSpinner(): void {
     `The Time-Spinner would not travel to a ${globalOptions.target}; it is no longer in the recent-fight list. Backing out of the choice and skipping this source for the rest of the run.`,
     HIGHLIGHT,
   );
-  if (handlingChoice() && lastChoice() === TRAVEL_TO_A_RECENT_FIGHT) {
-    runChoice(2); // Maybe Later
+  // A refusal can leave us on either Time-Spinner page -- in practice it bounces
+  // back to the 1195 menu -- and leaving one lands on the other, so drain them
+  // rather than handling a single hop. 1196 is not in mafia's canWalkFromChoice
+  // table and needs its explicit "Maybe Later"; 1195 is, so any non-choice
+  // request drops it and ChoiceManager clears handlingChoice for us.
+  let attempts = 0;
+  while (handlingChoice() && attempts++ < 3) {
+    const choice = lastChoice();
+    if (choice === TRAVEL_TO_A_RECENT_FIGHT) {
+      runChoice(2); // Maybe Later
+    } else if (choice === SPINNING_YOUR_TIME_SPINNER) {
+      visitUrl("main.php");
+    } else {
+      break;
+    }
   }
+
   if (handlingChoice()) {
     abort(
       `Still stuck in choice ${lastChoice()} after the Time-Spinner refused to fight a ${globalOptions.target}. Resolve it in the relay browser before continuing -- leaving a choice open breaks every later equipment change.`,

--- a/packages/garbo/src/target/fights.ts
+++ b/packages/garbo/src/target/fights.ts
@@ -985,6 +985,23 @@ export const emergencyChainStarters = [
         .filter((source) => source.potential() > 0)
         .map((source) => `${source.potential()} from ${source.name}`)
         .forEach((text) => print(text, HIGHLIGHT));
+
+      // WISH_VALUE is both the cost we assume above and the price cap we hand
+      // to acquire() below, so it is an upper bound on what we will actually
+      // pay for the wish -- the realised profit is never worse than `profit`.
+      // That makes `profit` safe to compare against a user threshold without a
+      // human in the loop. Deliberately don't touch askedAboutWish/wishAnswer:
+      // that cache exists to avoid re-prompting a person, and skipping it means
+      // every call re-checks the profit against current copy sources.
+      const autoWishThreshold = globalOptions.prefs.autoWishProfitThreshold;
+      if (autoWishThreshold >= 0 && profit >= autoWishThreshold) {
+        print(
+          `Automatically wishing for ${globalOptions.target}: expected profit of ${Math.round(profit)} meat meets your garbo_autoWishProfitThreshold of ${autoWishThreshold}.`,
+          HIGHLIGHT,
+        );
+        return true;
+      }
+
       globalOptions.askedAboutWish = true;
       globalOptions.wishAnswer = copyTargetConfirmInvocation(
         `Garbo has detected you have ${potential} potential ways to copy a ${

--- a/packages/garbo/src/target/fights.ts
+++ b/packages/garbo/src/target/fights.ts
@@ -272,9 +272,8 @@ const TIME_SPINNER_LOCATIONS = $locations`Noob Cave, The Dire Warren, The Haunte
 /**
  * Whether the target is in a combat queue the Time-Spinner draws from.
  *
- * `combatQueue` is a "; "-joined list, so match its entries rather than testing
- * for a substring -- a substring test claims a sea cow when only a sea cowboy
- * was fought.
+ * Matches entries exactly: a substring test claims a sea cow when only a sea
+ * cowboy was fought.
  * @returns Whether the target is in one of those queues
  */
 function targetInCombatQueue(): boolean {
@@ -283,22 +282,14 @@ function targetInCombatQueue(): boolean {
   );
 }
 
-/**
- * Whether the Time-Spinner has already declined to travel to our target this run.
- *
- * `combatQueue` is only an approximation of the Time-Spinner's recent-fight list, so
- * the target can pass our `available()` check and still not be on offer. When that
- * happens the game does not start a fight -- it just hands choice 1196 back -- and
- * we would otherwise keep spending the item on a list that will not have our target.
- */
+/** Whether the Time-Spinner has already declined to travel to our target. */
 let timeSpinnerRefusedTarget = false;
 
 /**
  * Leave the Time-Spinner choice after it declined to travel to a monster.
  *
- * This matters well beyond the wasted attempt: mafia cannot change equipment while a
- * choice is open, so an abandoned 1196 surfaces much later as "Failed to maximize
- * properly!" from whichever unrelated task next dresses an outfit.
+ * An open choice blocks every later equipment change, so leaving one surfaces
+ * far away as "Failed to maximize properly!".
  * @param monster The monster the Time-Spinner would not travel to
  */
 export function escapeRefusedTimeSpinner(monster: Monster): void {
@@ -306,11 +297,9 @@ export function escapeRefusedTimeSpinner(monster: Monster): void {
     `The Time-Spinner would not travel to a ${monster}; it is no longer in the recent-fight list. Backing out of the choice.`,
     HIGHLIGHT,
   );
-  // A refusal hands 1196 back, and leaving one Time-Spinner page can land on the
-  // other, so drain both rather than handling a single hop. 1196 is not in
-  // mafia's canWalkFromChoice table and needs its explicit "Maybe Later"; 1195
-  // is, so any non-choice request drops it and ChoiceManager clears
-  // handlingChoice for us.
+  // Leaving one Time-Spinner page can land on the other, so drain both. 1196 is
+  // not in mafia's canWalkFromChoice table and needs its "Maybe Later"; 1195 is,
+  // so any non-choice request drops it.
   let attempts = 0;
   while (handlingChoice() && attempts++ < 3) {
     const choice = lastChoice();
@@ -353,8 +342,7 @@ export const copySources = [
           visitUrl(
             `choice.php?whichchoice=${TRAVEL_TO_A_RECENT_FIGHT}&monid=${globalOptions.target.id}&option=1`,
           );
-          // A successful spin puts us in combat. If we are still sitting in a
-          // choice then the travel was refused and there is no fight to run.
+          // Still in a choice means the travel was refused; there is no fight.
           if (handlingChoice()) {
             timeSpinnerRefusedTarget = true;
             escapeRefusedTimeSpinner(globalOptions.target);
@@ -986,13 +974,10 @@ export const emergencyChainStarters = [
         .map((source) => `${source.potential()} from ${source.name}`)
         .forEach((text) => print(text, HIGHLIGHT));
 
-      // WISH_VALUE is both the cost we assume above and the price cap we hand
-      // to acquire() below, so it is an upper bound on what we will actually
-      // pay for the wish -- the realised profit is never worse than `profit`.
-      // That makes `profit` safe to compare against a user threshold without a
-      // human in the loop. Deliberately don't touch askedAboutWish/wishAnswer:
-      // that cache exists to avoid re-prompting a person, and skipping it means
-      // every call re-checks the profit against current copy sources.
+      // WISH_VALUE is both the assumed cost and the price cap given to
+      // acquire(), so realised profit is never worse than `profit` -- safe to
+      // compare against a threshold unattended. askedAboutWish/wishAnswer are
+      // left alone so each call re-checks profit against current copy sources.
       const autoWishThreshold = globalOptions.prefs.autoWishProfitThreshold;
       if (autoWishThreshold >= 0 && profit >= autoWishThreshold) {
         print(

--- a/packages/garbo/src/tasks/cockroach/prep.ts
+++ b/packages/garbo/src/tasks/cockroach/prep.ts
@@ -40,28 +40,17 @@ import { globalOptions } from "../../config";
 import { DebuffPlanner } from "./debuffplanner";
 import { meatMood } from "../../mood";
 import { potionSetup } from "../../potions";
-import { highMeatMonsterCount, potentialDietAdventures } from "../../turns";
+import { highMeatMonsterCount } from "../../turns";
 
-// PirateRealm costs ~40 adventures across the day, but only ~17 before this
-// quest stops at Trash Island: 8 sailing, 8 combats and a final encounter.
+// KoL will not start a voyage without this many adventures in hand.
 const PIRATEREALM_DAY_TURNS = 40;
-const PIRATEREALM_FIRST_LEG_TURNS = 17;
 
 /**
- * Whether PirateRealm is genuinely unaffordable rather than merely pre-diet.
- *
- * This runs before runDiet(), so myAdventures() here excludes the day's organ
- * adventures. Compare whole-day cost against whole-day supply, but still require
- * the first leg's turns to be in hand now.
+ * Whether the port will refuse to start a voyage.
  * @returns Whether to offer to retarget away from cockroach
  */
 function cannotAffordPirateRealm(): boolean {
-  const dayAdventures =
-    myAdventures() + (globalOptions.nodiet ? 0 : potentialDietAdventures());
-  return (
-    dayAdventures <= PIRATEREALM_DAY_TURNS ||
-    myAdventures() < PIRATEREALM_FIRST_LEG_TURNS
-  );
+  return myAdventures() <= PIRATEREALM_DAY_TURNS;
 }
 
 export const CockroachSetup: Quest<GarboTask> = {
@@ -79,7 +68,7 @@ export const CockroachSetup: Quest<GarboTask> = {
       do: () => {
         if (
           userConfirmDialog(
-            `You don't have enough adventures to do piraterealm (${myAdventures()} now, and we need ${PIRATEREALM_FIRST_LEG_TURNS} on hand plus about ${PIRATEREALM_DAY_TURNS} across the day, counting what the diet will provide); would you like us to automatically change your copy target to a Knob Goblin Guard? Otherwise, we're going to abort.`,
+            `You don't have enough adventures to do piraterealm (${myAdventures()} now, and we need more than ${PIRATEREALM_DAY_TURNS} in hand); would you like us to automatically change your copy target to a Knob Goblin Guard? Otherwise, we're going to abort.`,
             true,
           )
         ) {

--- a/packages/garbo/src/tasks/cockroach/prep.ts
+++ b/packages/garbo/src/tasks/cockroach/prep.ts
@@ -40,7 +40,40 @@ import { globalOptions } from "../../config";
 import { DebuffPlanner } from "./debuffplanner";
 import { meatMood } from "../../mood";
 import { potionSetup } from "../../potions";
-import { highMeatMonsterCount } from "../../turns";
+import { highMeatMonsterCount, potentialDietAdventures } from "../../turns";
+
+// PirateRealm costs roughly 40 adventures across the day. Only about 17 of them
+// are spent by this quest -- sailing to the first island (up to 8), its combats
+// (up to 8) and its final encounter (1). The rest go on sailing to Trash Island
+// and fighting there, which happens later in the day, after the diet has run.
+const PIRATEREALM_DAY_TURNS = 40;
+const PIRATEREALM_FIRST_LEG_TURNS = 17;
+
+/**
+ * Whether PirateRealm is genuinely unaffordable, as opposed to merely looking
+ * that way because we have not eaten yet.
+ *
+ * This quest deliberately runs before runDiet(). It has to: the copy target it
+ * may change is what diet prices consumables against, and doingGregFight()
+ * leans on `!dietCompleted` to decide we are still going to set up Greg fights,
+ * so running the diet first would flip that off for anyone relying on monster
+ * replacers. That ordering means myAdventures() here is a pre-diet count, and
+ * on its own it says nothing about how many adventures the day will have.
+ *
+ * So compare the whole-day cost against the whole-day supply, and separately
+ * require only the first leg's turns to be in hand right now -- the diet that
+ * pays for the remainder has not run yet, but it will before the remainder is
+ * spent.
+ * @returns Whether to offer to retarget away from cockroach
+ */
+function cannotAffordPirateRealm(): boolean {
+  const dayAdventures =
+    myAdventures() + (globalOptions.nodiet ? 0 : potentialDietAdventures());
+  return (
+    dayAdventures <= PIRATEREALM_DAY_TURNS ||
+    myAdventures() < PIRATEREALM_FIRST_LEG_TURNS
+  );
+}
 
 export const CockroachSetup: Quest<GarboTask> = {
   name: "Setup Cockroach Target",
@@ -52,12 +85,12 @@ export const CockroachSetup: Quest<GarboTask> = {
   tasks: [
     {
       name: "40 Adventure Failsafe",
-      ready: () => myAdventures() <= 40,
+      ready: () => cannotAffordPirateRealm(),
       completed: () => have($item`PirateRealm eyepatch`),
       do: () => {
         if (
           userConfirmDialog(
-            "You don't have enough adventures to do piraterealm; would you like us to automatically change your copy target to a Knob Goblin Guard? Otherwise, we're going to abort.",
+            `You don't have enough adventures to do piraterealm (${myAdventures()} now, and we need ${PIRATEREALM_FIRST_LEG_TURNS} on hand plus about ${PIRATEREALM_DAY_TURNS} across the day, counting what the diet will provide); would you like us to automatically change your copy target to a Knob Goblin Guard? Otherwise, we're going to abort.`,
             true,
           )
         ) {

--- a/packages/garbo/src/tasks/cockroach/prep.ts
+++ b/packages/garbo/src/tasks/cockroach/prep.ts
@@ -245,6 +245,12 @@ export const CockroachSetup: Quest<GarboTask> = {
               },
             ),
             avoid: $items`Roman Candelabra`,
+            // Every PirateRealm task has to keep all three stats at or under
+            // 100, and DebuffPlanner can only spend potions and effect removal
+            // to get there -- it never considers equipment. The outfit is
+            // dressed before prepare() runs, so any gear the maximizer picks
+            // for its stats is a flat overhead the planner cannot undo.
+            modifier: Stat.all().map((stat) => `-${stat}`),
           },
           get("_lastPirateRealmIsland", $location`none`),
         ),

--- a/packages/garbo/src/tasks/cockroach/prep.ts
+++ b/packages/garbo/src/tasks/cockroach/prep.ts
@@ -42,28 +42,17 @@ import { meatMood } from "../../mood";
 import { potionSetup } from "../../potions";
 import { highMeatMonsterCount, potentialDietAdventures } from "../../turns";
 
-// PirateRealm costs roughly 40 adventures across the day. Only about 17 of them
-// are spent by this quest -- sailing to the first island (up to 8), its combats
-// (up to 8) and its final encounter (1). The rest go on sailing to Trash Island
-// and fighting there, which happens later in the day, after the diet has run.
+// PirateRealm costs ~40 adventures across the day, but only ~17 before this
+// quest stops at Trash Island: 8 sailing, 8 combats and a final encounter.
 const PIRATEREALM_DAY_TURNS = 40;
 const PIRATEREALM_FIRST_LEG_TURNS = 17;
 
 /**
- * Whether PirateRealm is genuinely unaffordable, as opposed to merely looking
- * that way because we have not eaten yet.
+ * Whether PirateRealm is genuinely unaffordable rather than merely pre-diet.
  *
- * This quest deliberately runs before runDiet(). It has to: the copy target it
- * may change is what diet prices consumables against, and doingGregFight()
- * leans on `!dietCompleted` to decide we are still going to set up Greg fights,
- * so running the diet first would flip that off for anyone relying on monster
- * replacers. That ordering means myAdventures() here is a pre-diet count, and
- * on its own it says nothing about how many adventures the day will have.
- *
- * So compare the whole-day cost against the whole-day supply, and separately
- * require only the first leg's turns to be in hand right now -- the diet that
- * pays for the remainder has not run yet, but it will before the remainder is
- * spent.
+ * This runs before runDiet(), so myAdventures() here excludes the day's organ
+ * adventures. Compare whole-day cost against whole-day supply, but still require
+ * the first leg's turns to be in hand now.
  * @returns Whether to offer to retarget away from cockroach
  */
 function cannotAffordPirateRealm(): boolean {
@@ -245,11 +234,8 @@ export const CockroachSetup: Quest<GarboTask> = {
               },
             ),
             avoid: $items`Roman Candelabra`,
-            // Every PirateRealm task has to keep all three stats at or under
-            // 100, and DebuffPlanner can only spend potions and effect removal
-            // to get there -- it never considers equipment. The outfit is
-            // dressed before prepare() runs, so any gear the maximizer picks
-            // for its stats is a flat overhead the planner cannot undo.
+            // Stats must stay at or under 100, and DebuffPlanner only spends
+            // potions to get there -- gear stats are overhead it cannot undo.
             modifier: Stat.all().map((stat) => `-${stat}`),
           },
           get("_lastPirateRealmIsland", $location`none`),

--- a/packages/garbo/src/turns.ts
+++ b/packages/garbo/src/turns.ts
@@ -43,12 +43,7 @@ export function estimatedGarboTurns(estimateEmptyOrgans = true): number {
 
   // Estimate potential adventures from empty organs
   const unrealizedOrganAdventures = estimateEmptyOrgans
-    ? Math.max(
-        potentialFullnessAdventures() +
-          potentialInebrietyAdventures() +
-          potentialNonOrganAdventures(),
-        0,
-      )
+    ? potentialDietAdventures()
     : 0;
 
   let turns;
@@ -84,15 +79,9 @@ export function estimatedGarboTurns(estimateEmptyOrgans = true): number {
  * @returns A guess of how many turns will be used outside garbo
  */
 export function remainingUserTurns(): number {
-  const dietAdventures = Math.max(
-    potentialFullnessAdventures() +
-      potentialInebrietyAdventures() +
-      potentialNonOrganAdventures(),
-    0,
-  );
   const turns =
     myAdventures() +
-    dietAdventures -
+    potentialDietAdventures() -
     estimatedGarboTurns() +
     globalOptions.saveTurns;
   return turns;
@@ -126,6 +115,24 @@ function potentialInebrietyAdventures(): number {
       sweatSpace +
       shotglassSpace) *
     7
+  );
+}
+
+/**
+ * Computes the adventures we still expect to gain from filling our organs.
+ *
+ * This is what runDiet() is about to hand us, so it is the difference between
+ * the adventures we have at some point during setup and the adventures the day
+ * will actually have. Anything deciding whether we can afford a whole-day
+ * project before the diet has run needs to add this to myAdventures().
+ * @returns Adventures we expect to gain from food, booze and non-organ sources
+ */
+export function potentialDietAdventures(): number {
+  return Math.max(
+    potentialFullnessAdventures() +
+      potentialInebrietyAdventures() +
+      potentialNonOrganAdventures(),
+    0,
   );
 }
 

--- a/packages/garbo/src/turns.ts
+++ b/packages/garbo/src/turns.ts
@@ -121,10 +121,7 @@ function potentialInebrietyAdventures(): number {
 /**
  * Computes the adventures we still expect to gain from filling our organs.
  *
- * This is what runDiet() is about to hand us, so it is the difference between
- * the adventures we have at some point during setup and the adventures the day
- * will actually have. Anything deciding whether we can afford a whole-day
- * project before the diet has run needs to add this to myAdventures().
+ * Add this to myAdventures() when judging a whole-day cost before runDiet().
  * @returns Adventures we expect to gain from food, booze and non-organ sources
  */
 export function potentialDietAdventures(): number {

--- a/packages/garbo/src/turns.ts
+++ b/packages/garbo/src/turns.ts
@@ -16,6 +16,7 @@ import {
   ESTIMATED_OVERDRUNK_TURNS,
   howManySausagesCouldIEat,
   targetingMeat,
+  willDrunkAdventure,
 } from "./lib";
 import { embezzlerFights } from "./tasks/embezzler";
 import { nextWeekFights } from "./resources/sealclub";
@@ -34,9 +35,7 @@ export function estimatedGarboTurns(estimateEmptyOrgans = true): number {
   const thesisAdventures =
     have($familiar`Pocket Professor`) && !get("_thesisDelivered") ? 11 : 0;
   const nightcapAdventures =
-    globalOptions.ascend &&
-    myInebriety() <= inebrietyLimit() &&
-    have($item`Drunkula's wineglass`)
+    willDrunkAdventure() && myInebriety() <= inebrietyLimit()
       ? ESTIMATED_OVERDRUNK_TURNS
       : 0;
   const thumbRingMultiplier = usingThumbRing() ? 1 / 0.96 : 1;

--- a/packages/garbo/static/data/garbo_settings.json
+++ b/packages/garbo/static/data/garbo_settings.json
@@ -17,6 +17,11 @@
     "description": "Should skip verifying that your account has broken the prism? Set to true if you want to proceed regardless, and false if you'd like to be warned."
   },
   {
+    "name": "garbo_skipOverdrunkAdventures",
+    "type": "boolean",
+    "description": "Should garbo stop adventuring with Drunkula's wineglass while overdrunk? It still runs everything that does not cost a turn, so the day is finished rather than abandoned."
+  },
+  {
     "name": "garbo_valueOfFreeFight",
     "defaultValue": 2000,
     "description": "What is a free fight\run worth to you? (Default 2000)."


### PR DESCRIPTION
### Changes

- **`garbo_skipOverdrunkAdventures`** (default off): stops garbo adventuring with Drunkula's wineglass while overdrunk. Everything that costs no turn still runs, so the day is finished  afterwards. Without this, I would often attempt to go fight sea cows while overdrunk to poor results.

- **`garbo_autoWishProfitThreshold`** (default `-1`, always ask): skips the wish confirmation dialog when expected profit, after paying for the wish, is at least this many meat.

- **Time-Spinner refusal handling:** garbo now reads the offer list (`<select name="monid">` in choice 1196) before submitting a travel, escapes the choice when one is refused, and latches the source off for the run. Without the latch `available()` re-offers forever. An open choice blocks every later equipment change, so this previously surfaced as `Error: Failed to maximize properly!` Also fixes `targetInCombatQueue()` substring-matching `sea cow` against a queued `sea cowboy`.

- **Meat accessories priced against a stale location:** `usingThumbRing()` called `setLocation(Barf Mountain)` and never restored it, leaving every later `loc()`/`zone()`/`env()` modifier resolving against Barf Mountain. This would be bad if you're say, running in a different location like cowo wants to. It is memoized and called from diet and potion setup and persists for the run; it surfaced for me as PirateRealm setup maximizing against the wrong zone. Now wrapped in the existing `withLocation()` helper.

- **PirateRealm setup:**  two changes: Improving the 40 adventure failsafe a bit. Additionally, the setup outfit now maximizes `-mus/-mys/-mox`. `DebuffPlanner` only spends potions and effect removal, it didn't consider equipment, so stat gear the maximizer picks is flat overhead. This cropped up in a stat being pushed over 100 while I had the eyepatch on due to flat +mus.