### PR TITLE
Add garbo_skipOverdrunkAdventures

### DIFF
--- a/packages/garbo/src/config.ts
+++ b/packages/garbo/src/config.ts
@@ -225,6 +225,11 @@ You can use multiple options in conjunction, e.g. "garbo nobarf ascend"',
           setting: "garbo_skipAscensionCheck",
           help: "Set to true to skip verifying that your account has broken the prism, otherwise you will be warned upon starting the script.",
         }),
+        skipOverdrunkAdventures: Args.boolean({
+          setting: "garbo_skipOverdrunkAdventures",
+          help: "Set to true to stop garbo adventuring with Drunkula's wineglass while overdrunk. It still runs everything that does not cost a turn, so the day is finished rather than abandoned.",
+          default: false,
+        }),
         fightGlitch: Args.boolean({
           setting: "garbo_fightGlitch",
           help: "Set to true to fight the glitch season reward. You need certain skills, see relay for info.",

--- a/packages/garbo/src/familiar/lib.ts
+++ b/packages/garbo/src/familiar/lib.ts
@@ -126,13 +126,14 @@ export function canOpenRedPresent(): boolean {
 export function turnsAvailable(): number {
   const baseTurns = estimatedGarboTurns();
   const digitizes = wanderingCopytargetsRemaining();
-  const mapTurns = globalOptions.ascend
-    ? clamp(
-        availableAmount($item`Map to Safety Shelter Grimace Prime`),
-        0,
-        ESTIMATED_OVERDRUNK_TURNS,
-      )
-    : 0;
+  const mapTurns =
+    globalOptions.ascend && !globalOptions.prefs.skipOverdrunkAdventures
+      ? clamp(
+          availableAmount($item`Map to Safety Shelter Grimace Prime`),
+          0,
+          ESTIMATED_OVERDRUNK_TURNS,
+        )
+      : 0;
 
   const barfTurns = baseTurns - digitizes - mapTurns;
   const barfCombatRate = 1 - 1 / FarmingStrategy.turnsToNC();

--- a/packages/garbo/src/index.ts
+++ b/packages/garbo/src/index.ts
@@ -74,6 +74,7 @@ import {
   propertyManager,
   questStep,
   safeRestore,
+  skippingOverdrunkAdventures,
   targetingMeat,
   userConfirmDialog,
   valueDrops,
@@ -620,7 +621,19 @@ export function main(argString = ""): void {
         runGarboQuests([SetupTargetCopyQuest]);
         dailyFights();
 
-        if (!globalOptions.nobarf) {
+        if (!globalOptions.nobarf && skippingOverdrunkAdventures()) {
+          // 3. overdrunk with the wineglass benched: no turns to buff for, but
+          // the end of day tasks still need to run
+          print(
+            "Overdrunk and garbo_skipOverdrunkAdventures is set, so finishing up without adventuring.",
+            HIGHLIGHT,
+          );
+          try {
+            runGarboQuests([FinishUpQuest]);
+          } finally {
+            setAutoAttack(0);
+          }
+        } else if (!globalOptions.nobarf) {
           // 3. burn turns at barf
           potionSetup(false);
           maximize("MP", false);

--- a/packages/garbo/src/lib.ts
+++ b/packages/garbo/src/lib.ts
@@ -1174,7 +1174,15 @@ export function improvesAStat(thing: Item | Effect): boolean {
 }
 
 export function willDrunkAdventure() {
-  return have($item`Drunkula's wineglass`) && globalOptions.ascend;
+  return (
+    have($item`Drunkula's wineglass`) &&
+    globalOptions.ascend &&
+    !globalOptions.prefs.skipOverdrunkAdventures
+  );
+}
+
+export function skippingOverdrunkAdventures(): boolean {
+  return globalOptions.prefs.skipOverdrunkAdventures && !sober();
 }
 
 export function freeFishyAvailable(): boolean {

--- a/packages/garbo/src/turns.ts
+++ b/packages/garbo/src/turns.ts
@@ -16,6 +16,7 @@ import {
   ESTIMATED_OVERDRUNK_TURNS,
   howManySausagesCouldIEat,
   targetingMeat,
+  willDrunkAdventure,
 } from "./lib";
 import { embezzlerFights } from "./tasks/embezzler";
 import { nextWeekFights } from "./resources/sealclub";
@@ -34,9 +35,7 @@ export function estimatedGarboTurns(estimateEmptyOrgans = true): number {
   const thesisAdventures =
     have($familiar`Pocket Professor`) && !get("_thesisDelivered") ? 11 : 0;
   const nightcapAdventures =
-    globalOptions.ascend &&
-    myInebriety() <= inebrietyLimit() &&
-    have($item`Drunkula's wineglass`)
+    willDrunkAdventure() && myInebriety() <= inebrietyLimit()
       ? ESTIMATED_OVERDRUNK_TURNS
       : 0;
   const thumbRingMultiplier = usingThumbRing() ? 1 / 0.96 : 1;

--- a/packages/garbo/static/data/garbo_settings.json
+++ b/packages/garbo/static/data/garbo_settings.json
@@ -17,6 +17,11 @@
     "description": "Should skip verifying that your account has broken the prism? Set to true if you want to proceed regardless, and false if you'd like to be warned."
   },
   {
+    "name": "garbo_skipOverdrunkAdventures",
+    "type": "boolean",
+    "description": "Should garbo stop adventuring with Drunkula's wineglass while overdrunk? It still runs everything that does not cost a turn, so the day is finished rather than abandoned."
+  },
+  {
     "name": "garbo_valueOfFreeFight",
     "defaultValue": 2000,
     "description": "What is a free fight\run worth to you? (Default 2000)."


### PR DESCRIPTION
Opt-in toggle (default false) to stop garbo adventuring with Drunkula's wineglass while overdrunk. Everything that costs no turns still runs, so the day is finished. 

Currently, I get beat up by cows when running cowo with the wineglass, and I'm unsure there's anything my account has access to that would stop that from happening, so this is a backstop against that. 

Additionally could be useful if one thinks their marginal VoA tomorrow will be more valuable than their marginal VoA today and is not already overcapping their 200 adventure limit, but that gets more complex. Perhaps a future improvement atop this. 