### PR TITLE
Add garbo_autoWishProfitThreshold

### DIFF
--- a/packages/garbo/src/config.ts
+++ b/packages/garbo/src/config.ts
@@ -251,6 +251,11 @@ You can use multiple options in conjunction, e.g. "garbo nobarf ascend"',
           help: "This is used only when autoUserConfirm is true, will automatically use resources (such as pocket wishes, 11-leaf clovers, etc) up to this threshold to source a target monster for chaining before requesting user interference.",
           default: 1,
         }),
+        autoWishProfitThreshold: Args.number({
+          setting: "garbo_autoWishProfitThreshold",
+          help: "If 0 or greater, skip the confirmation dialog and wish for your copy target automatically whenever we have copies banked but no way to start a chain, and the expected profit (in meat, after paying for the wish) is at least this large. Negative values (the default) always ask. Genie fights remain capped at 3 per day.",
+          default: -1,
+        }),
         restoreHpTarget: Args.number({
           setting: "garbo_restoreHpTarget",
           help: "If you're a very high level, what HP threshold should garbo aim to maintain?",

--- a/packages/garbo/src/target/fights.ts
+++ b/packages/garbo/src/target/fights.ts
@@ -915,9 +915,8 @@ export const emergencyChainStarters = [
         .map((source) => `${source.potential()} from ${source.name}`)
         .forEach((text) => print(text, HIGHLIGHT));
       // WISH_VALUE is both the assumed cost and the price cap given to
-      // acquire(), so realised profit is never worse than `profit` -- safe to
-      // compare against a threshold unattended. askedAboutWish/wishAnswer are
-      // left alone so each call re-checks profit against current copy sources.
+      // acquire(), so realised profit is never worse than `profit`. Leaving
+      // askedAboutWish alone lets each call re-check against current sources.
       const autoWishThreshold = globalOptions.prefs.autoWishProfitThreshold;
       if (autoWishThreshold >= 0 && profit >= autoWishThreshold) {
         print(

--- a/packages/garbo/src/target/fights.ts
+++ b/packages/garbo/src/target/fights.ts
@@ -914,6 +914,19 @@ export const emergencyChainStarters = [
         .filter((source) => source.potential() > 0)
         .map((source) => `${source.potential()} from ${source.name}`)
         .forEach((text) => print(text, HIGHLIGHT));
+      // WISH_VALUE is both the assumed cost and the price cap given to
+      // acquire(), so realised profit is never worse than `profit` -- safe to
+      // compare against a threshold unattended. askedAboutWish/wishAnswer are
+      // left alone so each call re-checks profit against current copy sources.
+      const autoWishThreshold = globalOptions.prefs.autoWishProfitThreshold;
+      if (autoWishThreshold >= 0 && profit >= autoWishThreshold) {
+        print(
+          `Automatically wishing for ${globalOptions.target}: expected profit of ${Math.round(profit)} meat meets your garbo_autoWishProfitThreshold of ${autoWishThreshold}.`,
+          HIGHLIGHT,
+        );
+        return true;
+      }
+
       globalOptions.askedAboutWish = true;
       globalOptions.wishAnswer = copyTargetConfirmInvocation(
         `Garbo has detected you have ${potential} potential ways to copy a ${


### PR DESCRIPTION
Skips the wish confirmation dialog and wishes for the copy target automatically when copies are banked but there is no way to start a chain, and expected profit after paying for the wish is at least this many meat.

I think this is a bit separate from the "skip all dialog" permission that's currently up there. Currently, (though contributors may disagree) I think there's a marked difference in this dialog box (always good if profit is positive, though it is using a wish, which is worth flagging) versus something like "I can't do PirateRealm because of not enough adventures, so I'm going to abort your `target cockroach` and make a lot less money today without notifying you."