### PR TITLE
Restore the location after pricing meat accessories

### DIFF
--- a/packages/garbo/src/outfit/dropsgearAccessories.ts
+++ b/packages/garbo/src/outfit/dropsgearAccessories.ts
@@ -3,7 +3,6 @@ import {
   itemAmount,
   Modifier,
   myClass,
-  setLocation,
   stringModifier,
   toSlot,
 } from "kolmafia";
@@ -30,6 +29,7 @@ import {
   maxPassiveDamage,
   modeIsFree,
   monsterManuelAvailable,
+  withLocation,
 } from "../lib";
 import { maximumPinataCasts } from "../resources/yachtzee";
 import { globalOptions } from "../config";
@@ -217,21 +217,24 @@ export function usingThumbRing(): boolean {
     const gear = bonusAccessories(BonusEquipMode.BARF);
     const accessoryBonuses = [...gear.entries()].filter(([item]) => have(item));
 
-    setLocation(FarmingStrategy.location);
-    const meatAccessories = Item.all()
-      .filter(
-        (item) =>
-          have(item) &&
-          toSlot(item) === $slot`acc1` &&
-          getModifier("Meat Drop", item) > 0,
-      )
-      .map(
-        (item) =>
-          [item, (getModifier("Meat Drop", item) * baseMeat()) / 100] as [
-            Item,
-            number,
-          ],
-      );
+    // Mafia resolves env()/zone()/loc() modifiers against the last location
+    // set, so restore it or unrelated gear is priced against this one.
+    const meatAccessories = withLocation(FarmingStrategy.location, () =>
+      Item.all()
+        .filter(
+          (item) =>
+            have(item) &&
+            toSlot(item) === $slot`acc1` &&
+            getModifier("Meat Drop", item) > 0,
+        )
+        .map(
+          (item) =>
+            [item, (getModifier("Meat Drop", item) * baseMeat()) / 100] as [
+              Item,
+              number,
+            ],
+        ),
+    );
 
     const accessoryValues = new Map<Item, number>(accessoryBonuses);
     for (const [accessory, value] of meatAccessories) {


### PR DESCRIPTION
`usingThumbRing()` calls `setLocation()` to price Meat Drop accessories as they would perform while farming, but never puts the previous location back. 

With cowo, this means `underwater` leaks into land zone evaluations. 

Mafia resolves modifiers written against `loc()` / `zone()` / `env()` using that single global, so every later evaluation sees the farm location for gear valuation, maximizer runs, potion value. It is memoized and called from diet and potion setup, so this persists for the rest of the run.

`withLocation()` already exists for exactly this pattern and is already the idiom at `lib.ts:803` (Shadow Rift) and `potions.ts:758`. 